### PR TITLE
Simplified the README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Symfony Demo Application
 The "Symfony Demo Application" is a reference application created to show how
 to develop Symfony applications following the recommended best practices.
 
-[![Build Status](https://travis-ci.org/symfony/symfony-demo.svg?branch=master)](https://travis-ci.org/symfony/symfony-demo)
-
 Requirements
 ------------
 
@@ -13,63 +11,31 @@ Requirements
   * PDO-SQLite PHP extension enabled;
   * and the [usual Symfony application requirements](https://symfony.com/doc/current/reference/requirements.html).
 
-If unsure about meeting these requirements, download the demo application and
-browse the `http://localhost:8000/config.php` script to get more detailed
-information.
-
 Installation
 ------------
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
-
-First, install the [Symfony Installer](https://github.com/symfony/symfony-installer)
-if you haven't already. Then, install the Symfony Demo Application executing
-this command anywhere in your system:
+Execute this command to install the project:
 
 ```bash
-$ symfony demo
-
-# if you're using Windows:
-$ php symfony demo
+$ composer create symfony/symfony-demo
 ```
 
-If the `demo` command is not available, update your Symfony Installer to the
-most recent version executing the `symfony self-update` command.
-
-> **NOTE**
->
-> If you can't use the Symfony Installer, download and install the demo
-> application using Git and Composer:
->
->     $ git clone https://github.com/symfony/symfony-demo symfony_demo
->     $ cd symfony_demo/
->     $ composer install --no-interaction
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 Usage
 -----
 
-There is no need to configure a virtual host in your web server to access the application.
-Just use the built-in web server:
+There's no need to configure anything to run the application. Just execute this
+command to run the built-in web server and access the application in your
+browser at <http://localhost:8000>:
 
 ```bash
-$ cd symfony_demo/
+$ cd symfony-demo/
 $ php bin/console server:run
 ```
 
-This command will start a web server for the Symfony application. Now you can
-access the application in your browser at <http://localhost:8000>. You can
-stop the built-in web server by pressing `Ctrl + C` while you're in the
-terminal.
-
-> **NOTE**
->
-> If you want to use a fully-featured web server (like Nginx or Apache) to run
-> Symfony Demo application, configure it to point at the `web/` directory of the project.
-> For more details, see:
-> https://symfony.com/doc/current/cookbook/configuration/web_server_configuration.html
-
-Testing
--------
+Tests
+-----
 
 Execute this command to run tests:
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ Tests
 Execute this command to run tests:
 
 ```bash
-$ cd symfony_demo/
+$ cd symfony-demo/
 $ ./vendor/bin/simple-phpunit
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Requirements
 
   * PHP 7.1.3 or higher;
   * PDO-SQLite PHP extension enabled;
-  * and the [usual Symfony application requirements](https://symfony.com/doc/current/reference/requirements.html).
+  * and the [usual Symfony application requirements][1].
 
 Installation
 ------------
@@ -17,7 +17,7 @@ Installation
 Execute this command to install the project:
 
 ```bash
-$ composer create symfony/symfony-demo
+$ composer create-project symfony/symfony-demo
 ```
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
@@ -34,6 +34,9 @@ $ cd symfony-demo/
 $ php bin/console server:run
 ```
 
+Alternatively, you can [configure a fully-featured web server][2] like Nginx
+or Apache to run the application.
+
 Tests
 -----
 
@@ -43,3 +46,6 @@ Execute this command to run tests:
 $ cd symfony-demo/
 $ ./vendor/bin/simple-phpunit
 ```
+
+[1]: https://symfony.com/doc/current/reference/requirements.html
+[2]: https://symfony.com/doc/current/cookbook/configuration/web_server_configuration.html


### PR DESCRIPTION
This is needed because we're moving away from the Symfony Installer and we'll use Composer's create-project from now on.