### PR TITLE
Update Slovenian translations

### DIFF
--- a/translations/messages.sl.xlf
+++ b/translations/messages.sl.xlf
@@ -255,6 +255,10 @@
                 <source>menu.rss</source>
                 <target>RSS objav bloga</target>
             </trans-unit>
+            <trans-unit id="menu.search">
+                <source>menu.search</source>
+                <target>Iskanje</target>
+            </trans-unit>
 
             <trans-unit id="post.to_publish_a_comment">
                 <source>post.to_publish_a_comment</source>
@@ -287,6 +291,14 @@
             <trans-unit id="post.deleted_successfully">
                 <source>post.deleted_successfully</source>
                 <target>Objava uspešno izbrisana!</target>
+            </trans-unit>
+            <trans-unit id="post.search_for">
+                <source>post.search_for</source>
+                <target>Iskanje za ...</target>
+            </trans-unit>
+            <trans-unit id="post.search_no_results">
+                <source>post.search_no_results</source>
+                <target>Ni najdenih rezultatov</target>
             </trans-unit>
 
             <trans-unit id="notification.comment_created">


### PR DESCRIPTION
Hello, this patch updates Slovenian (sl_SI) translations according to the current English upstream version.