### PR TITLE
Remove the project ID, which should be different per project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
     },
     "extra": {
         "symfony": {
-            "id": "01BP22MQ00QH5WD6NN6HHD3EX4",
+            "id": "",
             "allow-contrib": true
         }
     }


### PR DESCRIPTION
When using the demo, people should get a new project id instead of a generic one.