### PR TITLE
Removed jQuery from auto provided variables in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ Encore
     .cleanupOutputBeforeBuild()
     .autoProvidejQuery()
     .autoProvideVariables({
-        "window.jQuery": "jquery",
         "window.Bloodhound": require.resolve('bloodhound-js'),
         "jQuery.tagsinput": "bootstrap-tagsinput"
     })


### PR DESCRIPTION
`window.jQuery` is already defined in `autoProvidejQuery` function, there's no need to override:

https://github.com/symfony/webpack-encore/blob/v0.9.1/lib/WebpackConfig.js#L271