### PR TITLE
Relying on default path for templates and translations directories

### DIFF
--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -2,9 +2,9 @@ monolog:
     handlers:
         main:
             type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            path: '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug
-            channels: ["!event"]
+            channels: ['!event']
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:
@@ -16,4 +16,4 @@ monolog:
         console:
             type:   console
             process_psr_3_messages: false
-            channels: ["!event", "!doctrine", "!console"]
+            channels: ['!event', '!doctrine', '!console']

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -9,9 +9,9 @@ monolog:
                 - ^/
         nested:
             type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            path: '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug
         console:
             type:   console
             process_psr_3_messages: false
-            channels: ["!event", "!doctrine"]
+            channels: ['!event', '!doctrine']

--- a/config/packages/translation.yaml
+++ b/config/packages/translation.yaml
@@ -1,7 +1,5 @@
 framework:
     default_locale: '%locale%'
     translator:
-        paths:
-            - '%kernel.project_dir%/config/translations/'
         fallbacks:
             - '%locale%'

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,5 +1,4 @@
 twig:
-    paths: ['%kernel.project_dir%/templates']
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
     form_themes:


### PR DESCRIPTION
Also, minor fixes related to quotation in monolog.yaml configuration.