### PR TITLE
[UX] Friendly command exceptions output

### DIFF
--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Utils\Validator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -207,7 +208,7 @@ class AddUserCommand extends Command
         $existingUser = $userRepository->findOneBy(['username' => $username]);
 
         if (null !== $existingUser) {
-            throw new \RuntimeException(sprintf('There is already a user registered with the "%s" username.', $username));
+            throw new RuntimeException(sprintf('There is already a user registered with the "%s" username.', $username));
         }
 
         // validate password and email if is not this input means interactive.
@@ -219,7 +220,7 @@ class AddUserCommand extends Command
         $existingEmail = $userRepository->findOneBy(['email' => $email]);
 
         if (null !== $existingEmail) {
-            throw new \RuntimeException(sprintf('There is already a user registered with the "%s" email.', $email));
+            throw new RuntimeException(sprintf('There is already a user registered with the "%s" email.', $email));
         }
     }
 

--- a/src/Command/DeleteUserCommand.php
+++ b/src/Command/DeleteUserCommand.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Utils\Validator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -112,7 +113,7 @@ HELP
         $user = $repository->findOneByUsername($username);
 
         if (null === $user) {
-            throw new \RuntimeException(sprintf('User with username "%s" not found.', $username));
+            throw new RuntimeException(sprintf('User with username "%s" not found.', $username));
         }
 
         // After an entity has been removed its in-memory state is the same

--- a/src/Utils/Validator.php
+++ b/src/Utils/Validator.php
@@ -11,6 +11,8 @@
 
 namespace App\Utils;
 
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+
 /**
  * This class is used to provide an example of integrating simple classes as
  * services into a Symfony application.
@@ -22,11 +24,11 @@ class Validator
     public function validateUsername(?string $username): string
     {
         if (empty($username)) {
-            throw new \Exception('The username can not be empty.');
+            throw new InvalidArgumentException('The username can not be empty.');
         }
 
         if (1 !== preg_match('/^[a-z_]+$/', $username)) {
-            throw new \Exception('The username must contain only lowercase latin characters and underscores.');
+            throw new InvalidArgumentException('The username must contain only lowercase latin characters and underscores.');
         }
 
         return $username;
@@ -35,11 +37,11 @@ class Validator
     public function validatePassword(?string $plainPassword): string
     {
         if (empty($plainPassword)) {
-            throw new \Exception('The password can not be empty.');
+            throw new InvalidArgumentException('The password can not be empty.');
         }
 
         if (mb_strlen(trim($plainPassword)) < 6) {
-            throw new \Exception('The password must be at least 6 characters long.');
+            throw new InvalidArgumentException('The password must be at least 6 characters long.');
         }
 
         return $plainPassword;
@@ -48,11 +50,11 @@ class Validator
     public function validateEmail(?string $email): string
     {
         if (empty($email)) {
-            throw new \Exception('The email can not be empty.');
+            throw new InvalidArgumentException('The email can not be empty.');
         }
 
         if (false === mb_strpos($email, '@')) {
-            throw new \Exception('The email should look like a real email.');
+            throw new InvalidArgumentException('The email should look like a real email.');
         }
 
         return $email;
@@ -61,7 +63,7 @@ class Validator
     public function validateFullName(?string $fullName): string
     {
         if (empty($fullName)) {
-            throw new \Exception('The full name can not be empty.');
+            throw new InvalidArgumentException('The full name can not be empty.');
         }
 
         return $fullName;


### PR DESCRIPTION
This is only a minor improvement that remove the short trace line where the exception was thrown, thus the output feels like a natural message (intentional) rather than an (unexpected) debuggeable error:

**before**
![delete-user-before](https://user-images.githubusercontent.com/2028198/33047796-9a006212-ce25-11e7-9f0c-dccfbf122d7b.png)

**after**
![delete-user-after](https://user-images.githubusercontent.com/2028198/33047800-a22f2b80-ce25-11e7-984b-cc48bdcf117d.png)

In general, by using the exception classes of the Console component should be better for user messages.