### PR TITLE
Allow PHP 7.2 & 7.3 and PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,13 @@ matrix:
   fast_finish: true
   include:
     - php: 7.1
+    - php: 7.2
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
 before_install:
-  - phpenv config-rm xdebug.ini
+  - '[[ "$TRAVIS_PHP_VERSION" == "nightly" ]] || phpenv config-rm xdebug.ini'
   - composer self-update
 
 install:
@@ -26,7 +30,7 @@ install:
 script:
   - ./vendor/bin/simple-phpunit
   # this checks that the source code follows the Symfony Code Syntax rules
-  - ./vendor/bin/php-cs-fixer fix --diff --dry-run -v
+  - '[[ "$TRAVIS_PHP_VERSION" == "nightly" ]] || ./vendor/bin/php-cs-fixer fix --diff --dry-run -v'
   # this checks that the YAML config files contain no syntax errors
   - ./bin/console lint:yaml config
   # this checks that the Twig template files contain no syntax errors

--- a/tests/Utils/ValidatorTest.php
+++ b/tests/Utils/ValidatorTest.php
@@ -34,13 +34,15 @@ class ValidatorTest extends TestCase
 
     public function testValidateUsernameEmpty()
     {
-        $this->setExpectedException('Exception', 'The username can not be empty.');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The username can not be empty.');
         $this->object->validateUsername(null);
     }
 
     public function testValidateUsernameInvalid()
     {
-        $this->setExpectedException('Exception', 'The username must contain only lowercase latin characters and underscores.');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The username must contain only lowercase latin characters and underscores.');
         $this->object->validateUsername('INVALID');
     }
 
@@ -53,13 +55,15 @@ class ValidatorTest extends TestCase
 
     public function testValidatePasswordEmpty()
     {
-        $this->setExpectedException('Exception', 'The password can not be empty.');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The password can not be empty.');
         $this->object->validatePassword(null);
     }
 
     public function testValidatePasswordInvalid()
     {
-        $this->setExpectedException('Exception', 'The password must be at least 6 characters long.');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The password must be at least 6 characters long.');
         $this->object->validatePassword('12345');
     }
 
@@ -72,13 +76,15 @@ class ValidatorTest extends TestCase
 
     public function testValidateEmailEmpty()
     {
-        $this->setExpectedException('Exception', 'The email can not be empty.');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The email can not be empty.');
         $this->object->validateEmail(null);
     }
 
     public function testValidateEmailInvalid()
     {
-        $this->setExpectedException('Exception', 'The email should look like a real email.');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The email should look like a real email.');
         $this->object->validateEmail('invalid');
     }
 
@@ -91,7 +97,8 @@ class ValidatorTest extends TestCase
 
     public function testValidateEmailFullName()
     {
-        $this->setExpectedException('Exception', 'The full name can not be empty.');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The full name can not be empty.');
         $this->object->validateFullName(null);
     }
 }


### PR DESCRIPTION
Switch to PHPUnit 6 `TestCase::expectException()` & `TestCase::expectExceptionMessage()` from PHPUnit 4 `TestCase::setExpectedException()`

Add PHP 7.2 & 7.3 (nightly) to Travis matrix with temporary workarounds for disable `xdebug` & `./vendor/bin/php-cs-fixer` until 7.3 full support

