### PR TITLE
Remove unnecessary configuration for controllers

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -30,12 +30,6 @@ services:
         # but if a service is unused, it's removed anyway
         exclude: '../src/{DataFixtures,Entity,Migrations,Tests}'
 
-    # controllers are imported separately to make sure they're public
-    # and have a tag that allows actions to type-hint services
-    App\Controller\:
-        resource: '../src/Controller'
-        tags: ['controller.service_arguments']
-
     # when the service definition only contains arguments, you can omit the
     # 'arguments' key and define the arguments just below the service class
     App\EventSubscriber\CommentNotificationSubscriber:


### PR DESCRIPTION
This configuration is only necessary for service controllers that don't extend from `Controller` or `AbstractController`, which is not the case here.

It is not clear in the recipe (in this sense) but the documentation is clear enough:
> http://symfony.com/doc/current/controller.html#fetching-services-as-controller-arguments
> If you're not using the default configuration, you can tag your service manually with `controller.service_arguments`.