### PR TITLE
Removes explicit dependency on DoctrineBundle.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "php": "^7.1.3",
         "ext-pdo_sqlite": "*",
-        "doctrine/doctrine-bundle": "^1.8",
         "doctrine/doctrine-fixtures-bundle": "^3.0",
         "erusev/parsedown": "^1.6",
         "ezyang/htmlpurifier": "^4.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4773cd5755c402b01fedfe6851ef269",
+    "content-hash": "e4397c2f405ca6748a36ce08c33a5439",
     "packages": [
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
This dependency is implicitly provided by `symfony/orm-pack`.