### PR TITLE
Adding debug pack.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 ###< symfony/framework-bundle ###
 
 ###> symfony/phpunit-bridge ###
+.phpunit
 /phpunit.xml
 ###< symfony/phpunit-bridge ###
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Execute this command to run tests:
 
 ```bash
 $ cd symfony-demo/
-$ ./vendor/bin/simple-phpunit
+$ php bin/phpunit
 ```
 
 [1]: https://symfony.com/doc/current/reference/requirements.html

--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+
+if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit')) {
+    echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
+    exit(1);
+}
+if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
+    putenv('SYMFONY_PHPUNIT_REMOVE=symfony/yaml');
+}
+if (false === getenv('SYMFONY_PHPUNIT_VERSION')) {
+    putenv('SYMFONY_PHPUNIT_VERSION=6.4');
+}
+if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
+    putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');
+}
+
+require dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit';

--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,8 @@
         "friendsofphp/php-cs-fixer": "^2.7",
         "symfony/browser-kit": "^4.0",
         "symfony/css-selector": "^4.0",
-        "symfony/debug-bundle": "^4.0",
+        "symfony/debug-pack": "^1.0",
         "symfony/dotenv": "^4.0",
-        "symfony/phpunit-bridge": "^4.0",
-        "symfony/profiler-pack": "^1.0",
-        "symfony/var-dumper": "^4.0",
         "symfony/web-server-bundle": "^4.0"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4397c2f405ca6748a36ce08c33a5439",
+    "content-hash": "06c8704491e0381e328604789e30aa03",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1748,16 +1748,16 @@
         },
         {
             "name": "sensio/framework-extra-bundle",
-            "version": "v5.1.1",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "4fc5d5ba02eee8bb02cc00548dfc5a98f6151fe8"
+                "reference": "28792a4e1a3237088ee1694098767833d079d56d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/4fc5d5ba02eee8bb02cc00548dfc5a98f6151fe8",
-                "reference": "4fc5d5ba02eee8bb02cc00548dfc5a98f6151fe8",
+                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/28792a4e1a3237088ee1694098767833d079d56d",
+                "reference": "28792a4e1a3237088ee1694098767833d079d56d",
                 "shasum": ""
             },
             "require": {
@@ -1813,7 +1813,7 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2017-11-30T14:53:48+00:00"
+            "time": "2017-12-01T00:43:37+00:00"
         },
         {
             "name": "sensiolabs/security-checker",
@@ -2587,16 +2587,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.0.42",
+            "version": "v1.0.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "a1117ae366eae895a449db63eda58035b112dda9"
+                "reference": "061fb1d3b3c5d3450afcb4d15c809a27ccdd4c3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/a1117ae366eae895a449db63eda58035b112dda9",
-                "reference": "a1117ae366eae895a449db63eda58035b112dda9",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/061fb1d3b3c5d3450afcb4d15c809a27ccdd4c3f",
+                "reference": "061fb1d3b3c5d3450afcb4d15c809a27ccdd4c3f",
                 "shasum": ""
             },
             "require": {
@@ -2629,7 +2629,7 @@
                     "email": "fabien.potencier@gmail.com"
                 }
             ],
-            "time": "2017-11-29T02:36:07+00:00"
+            "time": "2017-12-03T00:59:08+00:00"
         },
         {
             "name": "symfony/form",
@@ -4619,6 +4619,56 @@
             "time": "2017-10-19T11:52:38+00:00"
         },
         {
+            "name": "easycorp/easy-log-handler",
+            "version": "v1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/EasyCorp/easy-log-handler.git",
+                "reference": "79104f113f562ab6c677d482457d4474204d34a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/EasyCorp/easy-log-handler/zipball/79104f113f562ab6c677d482457d4474204d34a5",
+                "reference": "79104f113f562ab6c677d482457d4474204d34a5",
+                "shasum": ""
+            },
+            "require": {
+                "monolog/monolog": "~1.6",
+                "php": ">=5.3.0",
+                "symfony/yaml": "~2.3|~3.0|~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "EasyCorp\\EasyLog\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Javier Eguiluz",
+                    "email": "javiereguiluz@gmail.com"
+                },
+                {
+                    "name": "Project Contributors",
+                    "homepage": "https://github.com/EasyCorp/easy-log-handler"
+                }
+            ],
+            "description": "A handler for Monolog that optimizes log messages to be processed by humans instead of software. Improve your productivity with logs that are easy to understand.",
+            "homepage": "https://github.com/EasyCorp/easy-log-handler",
+            "keywords": [
+                "easy",
+                "log",
+                "logging",
+                "monolog",
+                "productivity"
+            ],
+            "time": "2017-10-20T08:47:57+00:00"
+        },
+        {
             "name": "friendsofphp/php-cs-fixer",
             "version": "v2.8.3",
             "source": {
@@ -5017,6 +5067,37 @@
             "description": "Symfony DebugBundle",
             "homepage": "https://symfony.com",
             "time": "2017-11-24T14:34:08+00:00"
+        },
+        {
+            "name": "symfony/debug-pack",
+            "version": "v1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug-pack.git",
+                "reference": "49e4492f347df60176375c285528f07ec1319f63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug-pack/zipball/49e4492f347df60176375c285528f07ec1319f63",
+                "reference": "49e4492f347df60176375c285528f07ec1319f63",
+                "shasum": ""
+            },
+            "require": {
+                "easycorp/easy-log-handler": "^1.0.2",
+                "php": "^7.0",
+                "symfony/debug-bundle": "^3.3|^4.0",
+                "symfony/monolog-bundle": "^3.0",
+                "symfony/phpunit-bridge": "^3.3|^4.0",
+                "symfony/profiler-pack": "^1.0",
+                "symfony/var-dumper": "^3.3|^4.0"
+            },
+            "type": "metapackage",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A debug pack for Symfony projects",
+            "time": "2017-11-09T14:26:26+00:00"
         },
         {
             "name": "symfony/dom-crawler",

--- a/config/packages/dev/easy_log_handler.yaml
+++ b/config/packages/dev/easy_log_handler.yaml
@@ -1,0 +1,16 @@
+services:
+    EasyCorp\EasyLog\EasyLogHandler:
+        public: false
+        arguments: ['%kernel.logs_dir%/%kernel.environment%.log']
+
+#// FIXME: How to add this configuration automatically without messing up with the monolog configuration?
+#monolog:
+#    handlers:
+#        buffered:
+#            type:     buffer
+#            handler:  easylog
+#            channels: ['!event']
+#            level:    debug
+#        easylog:
+#            type: service
+#            id:   EasyCorp\EasyLog\EasyLogHandler

--- a/config/packages/dev/easy_log_handler.yaml
+++ b/config/packages/dev/easy_log_handler.yaml
@@ -3,14 +3,8 @@ services:
         public: false
         arguments: ['%kernel.logs_dir%/%kernel.environment%.log']
 
-#// FIXME: How to add this configuration automatically without messing up with the monolog configuration?
-#monolog:
-#    handlers:
-#        buffered:
-#            type:     buffer
-#            handler:  easylog
-#            channels: ['!event']
-#            level:    debug
-#        easylog:
-#            type: service
-#            id:   EasyCorp\EasyLog\EasyLogHandler
+monolog:
+    handlers:
+        easylog:
+            type: service
+            id:   EasyCorp\EasyLog\EasyLogHandler

--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -1,8 +1,8 @@
 monolog:
     handlers:
         main:
-            type: stream
-            path: '%kernel.logs_dir%/%kernel.environment%.log'
+            type: buffer
+            handler: easylog
             level: debug
             channels: ['!event']
         # uncomment to get logging in your browser

--- a/symfony.lock
+++ b/symfony.lock
@@ -324,7 +324,7 @@
         "version": "v3.4.0-beta2"
     },
     "symfony/var-dumper": {
-        "version": "v3.4.0-beta2"
+        "version": "v4.0.0"
     },
     "symfony/debug-bundle": {
         "version": "3.3",
@@ -344,7 +344,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "3.3",
-            "ref": "0a66a0097def4db1cd03bcb3d4a268440ae4cb47"
+            "ref": "55a81726745b54cc6f8d845f1a094ed7d9ed2e32"
         }
     },
     "symfony/web-profiler-bundle": {
@@ -391,5 +391,17 @@
             "version": "1.2",
             "ref": "c1431086fec31f17fbcfe6d6d7e92059458facc1"
         }
+    },
+    "easycorp/easy-log-handler": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "70062abc2cd58794d2a90274502f81b55cd9951b"
+        }
+    },
+    "symfony/debug-pack": {
+        "version": "v1.0.3"
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,117 +1,27 @@
 {
-    "symfony/flex": {
-        "version": "1.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.0",
-            "ref": "e921bdbfe20cdefa3b82f379d1cd36df1bc8d115"
-        }
+    "composer/ca-bundle": {
+        "version": "1.0.8"
     },
-    "doctrine/collections": {
+    "composer/semver": {
+        "version": "1.4.2"
+    },
+    "dama/doctrine-test-bundle": {
+        "version": "v4.0.1"
+    },
+    "doctrine/annotations": {
         "version": "v1.5.0"
-    },
-    "symfony/polyfill-mbstring": {
-        "version": "v1.6.0"
-    },
-    "doctrine/lexer": {
-        "version": "v1.0.1"
-    },
-    "doctrine/inflector": {
-        "version": "v1.2.0"
     },
     "doctrine/cache": {
         "version": "v1.7.1"
     },
-    "doctrine/annotations": {
+    "doctrine/collections": {
         "version": "v1.5.0"
     },
     "doctrine/common": {
         "version": "v2.8.1"
     },
-    "symfony/doctrine-bridge": {
-        "version": "v3.4.0-beta2"
-    },
-    "doctrine/doctrine-cache-bundle": {
-        "version": "1.3.2"
-    },
-    "symfony/routing": {
-        "version": "3.3",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "5b2f0ee78c90d671860ac6450e37dec10fbc0719"
-        }
-    },
-    "paragonie/random_compat": {
-        "version": "v2.0.11"
-    },
-    "symfony/polyfill-php70": {
-        "version": "v1.6.0"
-    },
-    "symfony/http-foundation": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/event-dispatcher": {
-        "version": "v3.4.0-beta2"
-    },
-    "psr/log": {
-        "version": "1.0.2"
-    },
-    "symfony/debug": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/http-kernel": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/finder": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/filesystem": {
-        "version": "v3.4.0-beta2"
-    },
-    "psr/container": {
-        "version": "1.0.0"
-    },
-    "symfony/dependency-injection": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/config": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/polyfill-apcu": {
-        "version": "v1.6.0"
-    },
-    "psr/simple-cache": {
-        "version": "1.0.0"
-    },
-    "psr/cache": {
-        "version": "1.0.1"
-    },
-    "symfony/cache": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/framework-bundle": {
-        "version": "3.3",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "bcd70105a1e87e41f31af2ae84aaf948c8bfb189"
-        }
-    },
-    "symfony/console": {
-        "version": "3.3",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "5ec5bb098bc693cd92f03390dd488ea0847cfcc7"
-        }
-    },
-    "jdorn/sql-formatter": {
-        "version": "v1.2.17"
+    "doctrine/data-fixtures": {
+        "version": "v1.2.2"
     },
     "doctrine/dbal": {
         "version": "v2.6.2"
@@ -125,8 +35,8 @@
             "ref": "f29d6af1f605b9494a2c9c3a73cb1cacc6cca19b"
         }
     },
-    "doctrine/data-fixtures": {
-        "version": "v1.2.2"
+    "doctrine/doctrine-cache-bundle": {
+        "version": "1.3.2"
     },
     "doctrine/doctrine-fixtures-bundle": {
         "version": "2.4",
@@ -137,11 +47,38 @@
             "ref": "f2c3a6246cb5f36176f870bdc2e5f5b3cf6c454c"
         }
     },
+    "doctrine/doctrine-migrations-bundle": {
+        "version": "1.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.2",
+            "ref": "c1431086fec31f17fbcfe6d6d7e92059458facc1"
+        }
+    },
+    "doctrine/inflector": {
+        "version": "v1.2.0"
+    },
     "doctrine/instantiator": {
         "version": "1.1.0"
     },
-    "symfony/yaml": {
-        "version": "v3.4.0-beta2"
+    "doctrine/lexer": {
+        "version": "v1.0.1"
+    },
+    "doctrine/migrations": {
+        "version": "v1.6.0"
+    },
+    "doctrine/orm": {
+        "version": "v2.5.12"
+    },
+    "easycorp/easy-log-handler": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "70062abc2cd58794d2a90274502f81b55cd9951b"
+        }
     },
     "egulias/email-validator": {
         "version": "2.1.2"
@@ -152,6 +89,51 @@
     "ezyang/htmlpurifier": {
         "version": "v4.9.3"
     },
+    "friendsofphp/php-cs-fixer": {
+        "version": "2.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "2.2",
+            "ref": "9d60c231a92e69c68b89897813ec4931d0697b1f"
+        }
+    },
+    "gecko-packages/gecko-php-unit": {
+        "version": "v2.2"
+    },
+    "jdorn/sql-formatter": {
+        "version": "v1.2.17"
+    },
+    "monolog/monolog": {
+        "version": "1.23.0"
+    },
+    "ocramius/package-versions": {
+        "version": "1.1.3"
+    },
+    "ocramius/proxy-manager": {
+        "version": "2.1.1"
+    },
+    "pagerfanta/pagerfanta": {
+        "version": "v1.0.5"
+    },
+    "paragonie/random_compat": {
+        "version": "v2.0.11"
+    },
+    "php-cs-fixer/diff": {
+        "version": "v1.2.0"
+    },
+    "psr/cache": {
+        "version": "1.0.1"
+    },
+    "psr/container": {
+        "version": "1.0.0"
+    },
+    "psr/log": {
+        "version": "1.0.2"
+    },
+    "psr/simple-cache": {
+        "version": "1.0.0"
+    },
     "sensio/framework-extra-bundle": {
         "version": "4.0",
         "recipe": {
@@ -160,9 +142,6 @@
             "version": "4.0",
             "ref": "aaddfdf43cdecd4cf91f992052d76c2cadc04543"
         }
-    },
-    "composer/ca-bundle": {
-        "version": "1.0.8"
     },
     "sensiolabs/security-checker": {
         "version": "4.0",
@@ -173,32 +152,104 @@
             "ref": "576d653444dade07f272c889d52fe4594caa4fc3"
         }
     },
+    "swiftmailer/swiftmailer": {
+        "version": "v6.0.2"
+    },
     "symfony/asset": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/browser-kit": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/cache": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/config": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/console": {
+        "version": "3.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.3",
+            "ref": "5ec5bb098bc693cd92f03390dd488ea0847cfcc7"
+        }
+    },
+    "symfony/css-selector": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/debug": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/debug-bundle": {
+        "version": "3.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.3",
+            "ref": "de31e687f3964939abd1f66817bd96ed34bc2eee"
+        }
+    },
+    "symfony/debug-pack": {
+        "version": "v1.0.3"
+    },
+    "symfony/dependency-injection": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/doctrine-bridge": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/dom-crawler": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/dotenv": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/event-dispatcher": {
         "version": "v3.4.0-beta2"
     },
     "symfony/expression-language": {
         "version": "v3.4.0-beta2"
     },
-    "symfony/inflector": {
+    "symfony/filesystem": {
         "version": "v3.4.0-beta2"
     },
-    "symfony/property-access": {
+    "symfony/finder": {
         "version": "v3.4.0-beta2"
     },
-    "symfony/options-resolver": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/intl": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/polyfill-intl-icu": {
-        "version": "v1.6.0"
+    "symfony/flex": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "e921bdbfe20cdefa3b82f379d1cd36df1bc8d115"
+        }
     },
     "symfony/form": {
         "version": "v3.4.0-beta2"
     },
-    "monolog/monolog": {
-        "version": "1.23.0"
+    "symfony/framework-bundle": {
+        "version": "3.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.3",
+            "ref": "bcd70105a1e87e41f31af2ae84aaf948c8bfb189"
+        }
+    },
+    "symfony/http-foundation": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/http-kernel": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/inflector": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/intl": {
+        "version": "v3.4.0-beta2"
     },
     "symfony/monolog-bridge": {
         "version": "v3.4.0-beta2"
@@ -212,11 +263,53 @@
             "ref": "94d0b0b417e988466de57cea583f83b396e44661"
         }
     },
-    "doctrine/orm": {
-        "version": "v2.5.12"
+    "symfony/options-resolver": {
+        "version": "v3.4.0-beta2"
     },
     "symfony/orm-pack": {
         "version": "v1.0.4"
+    },
+    "symfony/phpunit-bridge": {
+        "version": "3.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.3",
+            "ref": "55a81726745b54cc6f8d845f1a094ed7d9ed2e32"
+        }
+    },
+    "symfony/polyfill-apcu": {
+        "version": "v1.6.0"
+    },
+    "symfony/polyfill-intl-icu": {
+        "version": "v1.6.0"
+    },
+    "symfony/polyfill-mbstring": {
+        "version": "v1.6.0"
+    },
+    "symfony/polyfill-php70": {
+        "version": "v1.6.0"
+    },
+    "symfony/polyfill-php72": {
+        "version": "v1.6.0"
+    },
+    "symfony/process": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/profiler-pack": {
+        "version": "v1.0.2"
+    },
+    "symfony/property-access": {
+        "version": "v3.4.0-beta2"
+    },
+    "symfony/routing": {
+        "version": "3.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.3",
+            "ref": "5b2f0ee78c90d671860ac6450e37dec10fbc0719"
+        }
     },
     "symfony/security": {
         "version": "v3.4.0-beta2"
@@ -230,8 +323,8 @@
             "ref": "85834af1496735f28d831489d12ab1921a875e0d"
         }
     },
-    "swiftmailer/swiftmailer": {
-        "version": "v6.0.2"
+    "symfony/stopwatch": {
+        "version": "v3.4.0-beta2"
     },
     "symfony/swiftmailer-bundle": {
         "version": "2.5",
@@ -251,21 +344,6 @@
             "ref": "58f37511a2ceec2761716413ce679cbe118e37c3"
         }
     },
-    "symfony/validator": {
-        "version": "v3.4.0-beta2"
-    },
-    "twig/twig": {
-        "version": "v2.4.4"
-    },
-    "twig/extensions": {
-        "version": "1.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.0",
-            "ref": "4851df0afc426b8f07204379d21fca25b6df5d68"
-        }
-    },
     "symfony/twig-bridge": {
         "version": "v3.4.0-beta2"
     },
@@ -278,74 +356,11 @@
             "ref": "42324de95dde296ef158f48d6cf7fefddd18da7d"
         }
     },
-    "pagerfanta/pagerfanta": {
-        "version": "v1.0.5"
-    },
-    "white-october/pagerfanta-bundle": {
-        "version": "v1.0.8"
-    },
-    "dama/doctrine-test-bundle": {
-        "version": "v4.0.1"
-    },
-    "symfony/stopwatch": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/process": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/polyfill-php72": {
-        "version": "v1.6.0"
-    },
-    "php-cs-fixer/diff": {
-        "version": "v1.2.0"
-    },
-    "gecko-packages/gecko-php-unit": {
-        "version": "v2.2"
-    },
-    "composer/semver": {
-        "version": "1.4.2"
-    },
-    "friendsofphp/php-cs-fixer": {
-        "version": "2.2",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "2.2",
-            "ref": "9d60c231a92e69c68b89897813ec4931d0697b1f"
-        }
-    },
-    "symfony/dom-crawler": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/browser-kit": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/css-selector": {
+    "symfony/validator": {
         "version": "v3.4.0-beta2"
     },
     "symfony/var-dumper": {
         "version": "v4.0.0"
-    },
-    "symfony/debug-bundle": {
-        "version": "3.3",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "de31e687f3964939abd1f66817bd96ed34bc2eee"
-        }
-    },
-    "symfony/dotenv": {
-        "version": "v3.4.0-beta2"
-    },
-    "symfony/phpunit-bridge": {
-        "version": "3.3",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "55a81726745b54cc6f8d845f1a094ed7d9ed2e32"
-        }
     },
     "symfony/web-profiler-bundle": {
         "version": "3.3",
@@ -356,9 +371,6 @@
             "ref": "6bdfa1a95f6b2e677ab985cd1af2eae35d62e0f6"
         }
     },
-    "symfony/profiler-pack": {
-        "version": "v1.0.2"
-    },
     "symfony/web-server-bundle": {
         "version": "3.3",
         "recipe": {
@@ -368,40 +380,28 @@
             "ref": "c72d107d077f1654428edaed69415d0228c1aefe"
         }
     },
-    "ocramius/package-versions": {
-        "version": "1.1.3"
+    "symfony/yaml": {
+        "version": "v3.4.0-beta2"
     },
-    "zendframework/zend-eventmanager": {
-        "version": "3.2.0"
-    },
-    "zendframework/zend-code": {
-        "version": "3.3.0"
-    },
-    "ocramius/proxy-manager": {
-        "version": "2.1.1"
-    },
-    "doctrine/migrations": {
-        "version": "v1.6.0"
-    },
-    "doctrine/doctrine-migrations-bundle": {
-        "version": "1.2",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.2",
-            "ref": "c1431086fec31f17fbcfe6d6d7e92059458facc1"
-        }
-    },
-    "easycorp/easy-log-handler": {
+    "twig/extensions": {
         "version": "1.0",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "1.0",
-            "ref": "70062abc2cd58794d2a90274502f81b55cd9951b"
+            "ref": "4851df0afc426b8f07204379d21fca25b6df5d68"
         }
     },
-    "symfony/debug-pack": {
-        "version": "v1.0.3"
+    "twig/twig": {
+        "version": "v2.4.4"
+    },
+    "white-october/pagerfanta-bundle": {
+        "version": "v1.0.8"
+    },
+    "zendframework/zend-code": {
+        "version": "3.3.0"
+    },
+    "zendframework/zend-eventmanager": {
+        "version": "3.2.0"
     }
 }


### PR DESCRIPTION
I had to edit `symfony.lock` by hand in order to make diff not too scary.

It would be an awesome feature to have `symfony.lock` sorted alphabetically as it is happening with `composer.lock`. :(

There's still `TODO` item in monolog `EasyCorp\EasyLog\EasyLogHandler` handler on how to solve configuring it which I think might be a blocker for introducing `debug-pack` here. I've solved it in a way I'm using `debug-pack` in my project.