### PR TITLE
Adds Doctrine's mapping validation on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,5 @@ script:
   - ./bin/console security:check --end-point=http://security.sensiolabs.org/check_lock
   # this checks that the composer.json and composer.lock files are valid
   - composer validate --strict
+  # this checks that Doctrine's mapping configurations are valid
+  - ./bin/console doctrine:schema:validate --skip-sync -vvv --no-interaction


### PR DESCRIPTION
Runs `doctrine:schema:validate` command with database sync skipping and
no interaction flags.

This is what I usually setup in CI for my projects to avoid common Doctrine's mapping errors e.g. missing `inversedBy` properties.