### PR TITLE
[Validators PL translation] Fixing declension.

### DIFF
--- a/translations/validators.pl.xlf
+++ b/translations/validators.pl.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Treść artykułu jest za krótka (minimum: {{ limit }} znaków)</target>
+                <target>Treść artykułu jest za krótka (minimum: {{ limit }} znak)|Treść artykułu jest za krótka (minimum: {{ limit }} znaki)|Treść artykułu jest za krótka (minimum: {{ limit }} znaków)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Twój komentarz jest za krótki (minimum: {{ limit }} znaków)</target>
+                <target>Twój komentarz jest za krótki (minimum: {{ limit }} znak)|Twój komentarz jest za krótki (minimum: {{ limit }} znaki)|Twój komentarz jest za krótki (minimum: {{ limit }} znaków)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Twój komentarz jest za długi (maksimum: {{ limit }} znaków)</target>
+                <target>Twój komentarz jest za długi (maksimum: {{ limit }} znak)|Twój komentarz jest za długi (maksimum: {{ limit }} znaki)|Twój komentarz jest za długi (maksimum: {{ limit }} znaków)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>


### PR DESCRIPTION
Small fix on PL validators translation to support message declension.

Done in the same way as it was done in CS validators translation.

P.S. I've closed previous PR because I've used wrong account. Sorry for the problem.