### PR TITLE
Tags fixtures with `doctrine.fixture.orm`.

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -28,7 +28,11 @@ services:
         resource: '../src/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../src/{Entity,Migrations,Tests}'
+        exclude: '../src/{DataFixtures,Entity,Migrations,Tests}'
+
+    App\DataFixtures\:
+        resource: '../src/DataFixtures/*'
+        tags: [doctrine.fixture.orm]
 
     # when the service definition only contains arguments, you can omit the
     # 'arguments' key and define the arguments just below the service class

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -30,6 +30,7 @@ services:
         # but if a service is unused, it's removed anyway
         exclude: '../src/{DataFixtures,Entity,Migrations,Tests}'
 
+    # tags fixtures classes for DoctrineFixturesBundle
     App\DataFixtures\:
         resource: '../src/DataFixtures/*'
         tags: [doctrine.fixture.orm]


### PR DESCRIPTION
`^3.0` releases of `DoctrineFixturesBundle` treats services as fixtures when they're tagged with `doctrine.orm.fixture`.

Not sure if this is the most optimal way to do it.

Before:

```bash
php bin/console doctrine:fixtures:load -n

In LoadDataFixturesDoctrineCommand.php line 95:
                                                
  Could not find any fixture services to load.                                    
```
After:

```bash
php bin/console doctrine:fixtures:load -n  
  > purging database
  > loading App\DataFixtures\UserFixtures
  > loading App\DataFixtures\TagFixtures
  > loading App\DataFixtures\PostFixtures
```