### PR TITLE
Fix Doctrine fixtures service auto-configuration

### DIFF
--- a/src/DataFixtures/PostFixtures.php
+++ b/src/DataFixtures/PostFixtures.php
@@ -15,6 +15,7 @@ use App\Entity\Comment;
 use App\Entity\Post;
 use App\Entity\User;
 use App\Utils\Slugger;
+use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
@@ -31,7 +32,7 @@ use Doctrine\Common\Persistence\ObjectManager;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
-class PostFixtures extends AbstractFixture implements DependentFixtureInterface
+class PostFixtures extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     use FixturesTrait;
 

--- a/src/DataFixtures/TagFixtures.php
+++ b/src/DataFixtures/TagFixtures.php
@@ -12,6 +12,7 @@
 namespace App\DataFixtures;
 
 use App\Entity\Tag;
+use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\Persistence\ObjectManager;
 
@@ -25,7 +26,7 @@ use Doctrine\Common\Persistence\ObjectManager;
  *
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
-class TagFixtures extends AbstractFixture
+class TagFixtures extends AbstractFixture implements ORMFixtureInterface
 {
     use FixturesTrait;
 

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -12,6 +12,7 @@
 namespace App\DataFixtures;
 
 use App\Entity\User;
+use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -29,7 +30,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
-class UserFixtures extends AbstractFixture implements ContainerAwareInterface
+class UserFixtures extends AbstractFixture implements ORMFixtureInterface, ContainerAwareInterface
 {
     use ContainerAwareTrait;
 


### PR DESCRIPTION
I've missed this during the update to DoctrineFixturesBundle 3.0