### PR TITLE
Use rootform test to check by root form view

### DIFF
--- a/templates/form/layout.html.twig
+++ b/templates/form/layout.html.twig
@@ -4,13 +4,13 @@
 
 {% block form_errors -%}
     {% if errors|length > 0 -%}
-        {% if form.parent %}<span class="help-block">{% else %}<div class="alert alert-danger">{% endif %}
+        {% if form is not rootform %}<span class="help-block">{% else %}<div class="alert alert-danger">{% endif %}
         <ul class="list-unstyled">
         {%- for error in errors -%}
             {# use font-awesome icon library #}
             <li><span class="fa fa-exclamation-triangle"></span> {{ error.message }}</li>
         {%- endfor -%}
         </ul>
-        {% if form.parent %}</span>{% else %}</div>{% endif %}
+        {% if form is not rootform %}</span>{% else %}</div>{% endif %}
     {%- endif %}
 {%- endblock form_errors %}


### PR DESCRIPTION
This is consistent with the latest changes in the form themes and avoids any future collision between form view properties and form fields.

See https://github.com/symfony/symfony/pull/25236