### PR TITLE
Allow to search blog posts with unicode characters

### DIFF
--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -94,7 +94,7 @@ class PostRepository extends ServiceEntityRepository
      */
     private function sanitizeSearchQuery(string $query): string
     {
-        return preg_replace('/[^[:alnum:] ]/', '', trim(preg_replace('/[[:space:]]+/', ' ', $query)));
+        return trim(preg_replace('/[[:space:]]+/', ' ', $query));
     }
 
     /**
@@ -102,7 +102,7 @@ class PostRepository extends ServiceEntityRepository
      */
     private function extractSearchTerms(string $searchQuery): array
     {
-        $terms = array_unique(explode(' ', mb_strtolower($searchQuery)));
+        $terms = array_unique(explode(' ', $searchQuery));
 
         return array_filter($terms, function ($term) {
             return 2 <= mb_strlen($term);


### PR DESCRIPTION
This fixes #734.

The search engine is now more strict because it's case sensitive (if the post title is `Lorém ipsum`, `lorém` and `Lorem` gives no results; you must search for `Lorém`). I'd say it's OK because we're not building a real search engine. Thoughts?