### PR TITLE
Reduce the BCrypt cost in tests to run them much faster

### DIFF
--- a/config/packages/test/security.yaml
+++ b/config/packages/test/security.yaml
@@ -1,6 +1,11 @@
 # this configuration simplifies testing URLs protected by the security mechanism
 # See https://symfony.com/doc/current/cookbook/testing/http_authentication.html
 security:
+    encoders:
+        # to make tests much faster, BCrypt cost is changed to its minimum allowed value (4)
+        # See https://symfony.com/doc/current/reference/configuration/security.html#using-the-bcrypt-password-encoder
+        App\Entity\User: { algorithm: bcrypt, cost: 4 }
+
     firewalls:
         main:
             http_basic: ~


### PR DESCRIPTION
I learned this cool trick from this @taylorotwell tweet: https://twitter.com/taylorotwell/status/943135617466105856

In my local machine, tests went from 15 to 10 seconds!