### PR TITLE
Use Twig Bundle in require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "symfony/security-bundle": "^4.0",
         "symfony/swiftmailer-bundle": "^3.1",
         "symfony/translation": "^4.0",
+        "symfony/twig-bundle": "^4.0",
         "symfony/validator": "^4.0",
         "symfony/yaml": "^4.0",
         "twig/extensions": "^1.5",
-        "twig/twig": "^2.4",
         "white-october/pagerfanta-bundle": "^1.1"
     },
     "require-dev": {
@@ -39,7 +39,6 @@
         "symfony/dotenv": "^4.0",
         "symfony/phpunit-bridge": "^4.0",
         "symfony/stopwatch": "^4.0",
-        "symfony/twig-bundle": "^4.0",
         "symfony/web-profiler-bundle": "^4.0",
         "symfony/web-server-bundle": "^4.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a833d90fb331544000a32e014ed667cb",
+    "content-hash": "dfbd276982fbca323f374d038ff1eed8",
     "packages": [
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
I think you must use twig-bundle directly in require section because it is needed for project to run with composer --no-dev for example. It can easily replace twig dependency because twig bundle depends of twig :)