### PR TITLE
Keep the services.yaml file in sync with the default Symfony file

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -9,15 +9,12 @@ parameters:
 services:
     # default configuration for services in *this* file
     _defaults:
-        # automatically injects dependencies in your services
-        autowire: true
-        # automatically registers your services as commands, event subscribers, etc.
-        autoconfigure: true
-        # this means you cannot fetch services directly from the container via $container->get()
-        # if you need to do this, you can override this setting on individual services
-        public: false
-        # defines the scalar arguments once and apply them to any service defined/created in this file
-        bind:
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+        public: false       # Allows optimizing the container by removing unused services; this also means
+                            # fetching services directly from the container via $container->get() won't work.
+                            # The best practice is to be explicit about your dependencies anyway.
+        bind:               # defines the scalar arguments once and apply them to any service defined/created in this file
             $locales: '%app_locales%'
             $defaultLocale: '%locale%'
             $emailSender: '%app.notifications.email_sender%'
@@ -26,9 +23,13 @@ services:
     # this creates a service per class whose id is the fully-qualified class name
     App\:
         resource: '../src/*'
-        # you can exclude directories or files
-        # but if a service is unused, it's removed anyway
-        exclude: '../src/{Entity,Migrations,Tests}'
+        exclude: '../src/{Entity,Migrations,Tests,Kernel.php}'
+
+    # controllers are imported separately to make sure services can be injected
+    # as action arguments even if you don't extend any base controller class
+    App\Controller\:
+        resource: '../src/Controller'
+        tags: ['controller.service_arguments']
 
     # when the service definition only contains arguments, you can omit the
     # 'arguments' key and define the arguments just below the service class


### PR DESCRIPTION
In this demo app we always keep config files in sync with those provided by the Symfony recipes. This makes the config easier to understand for newcomers (there will be no surprises because when they install Symfony, they'll get the same config they saw on this app).

In addition, I think it's a good idea to keep the `App\Controller\` config. It's true that technically we don't need it because our controllers extend from the base controller. But having this config explicitly, makes it easier to understand what's going on with the services created from controllers.