### PR TITLE
disable the deprecated sensio_framework_extra.router.annotations

### DIFF
--- a/config/packages/framework_extra.yaml
+++ b/config/packages/framework_extra.yaml
@@ -1,6 +1,3 @@
-framework:
-    annotations: true
-
 sensio_framework_extra:
         router:
             annotations: false

--- a/config/packages/framework_extra.yaml
+++ b/config/packages/framework_extra.yaml
@@ -1,2 +1,6 @@
 framework:
     annotations: true
+
+sensio_framework_extra:
+        router:
+            annotations: false


### PR DESCRIPTION
fixes #786 

`famework.annotations` still needs to be true due to the `validation: { enable_annotations: true }` in `framework.yaml`. 

Should I move the `framework.annotations: true` to the `framework.yaml` file instead? It seems more appropriate.