### PR TITLE
Remove default flex id

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,6 @@
     },
     "extra": {
         "symfony": {
-            "id": "01BY8QJHBGTYRP06WQFNY99EKP",
             "allow-contrib": true
         }
     }


### PR DESCRIPTION
Not needed anymore after symfony/flex#363