### PR TITLE
Fix bug when loading bundles classes by environment

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -38,7 +38,7 @@ class Kernel extends BaseKernel
     {
         $contents = require $this->getProjectDir().'/config/bundles.php';
         foreach ($contents as $class => $envs) {
-            if (isset($envs['all']) || isset($envs[$this->environment])) {
+            if (!empty($envs['all']) || !empty($envs[$this->environment])) {
                 yield new $class();
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Original PR: https://github.com/symfony/recipes/pull/417

Bundle classes are not loaded correctly, for example:
```php
// config/bundles.php
<?php

return [
Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['dev' => false, 'prod' => true],
```
The FrameworkBundle will be loaded for both **dev** and for **prod** environments even with `'dev' => false` !!
  
Same thing for:
```php
// config/bundles.php
<?php

return [
Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => false],
```