### PR TITLE
require phpunit 7.1 via SYMFONY_PHPUNIT_VERSION env variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 env:
   global:
     - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
-    - SYMFONY_PHPUNIT_VERSION="6.3"
 
 matrix:
   fast_finish: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
         <env name="APP_ENV" value="test"/>
         <env name="APP_DEBUG" value="1"/>
         <env name="APP_SECRET" value="5a79a1c866efef9ca1800f971d689f3e"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="7.1"/>
         <!-- define your env variables for the test env here -->
 
         <!-- ###+ doctrine/doctrine-bundle ### -->


### PR DESCRIPTION
Fixes https://github.com/symfony/demo/issues/811

When running the test suite on php 7.1 the wrong phpunit (non-maintained version 5) is required by the simple-phpunit-bridge which is not compatible with https://github.com/dmaicher/doctrine-test-bundle-demo.