### PR TITLE
Add help messages to some form fields

### DIFF
--- a/src/Form/CommentType.php
+++ b/src/Form/CommentType.php
@@ -13,6 +13,7 @@ namespace App\Form;
 
 use App\Entity\Comment;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -40,7 +41,9 @@ class CommentType extends AbstractType
         // $builder->add('content', null, ['required' => false]);
 
         $builder
-            ->add('content')
+            ->add('content', TextareaType::class, [
+                'help' => 'Comments not complying with our Code of Conduct will be moderated.',
+            ])
         ;
     }
 

--- a/src/Form/PostType.php
+++ b/src/Form/PostType.php
@@ -48,14 +48,17 @@ class PostType extends AbstractType
                 'label' => 'label.title',
             ])
             ->add('summary', TextareaType::class, [
+                'help' => 'Summaries can\'t contain Markdown or HTML contents; only plain text.',
                 'label' => 'label.summary',
             ])
             ->add('content', null, [
                 'attr' => ['rows' => 20],
+                'help' => 'Use Markdown to format the blog post contents. HTML is allowed too.',
                 'label' => 'label.content',
             ])
             ->add('publishedAt', DateTimePickerType::class, [
                 'label' => 'label.published_at',
+                'help' => 'Set the date in the future to schedule the blog post publication.',
             ])
             ->add('tags', TagsInputType::class, [
                 'label' => 'label.tags',

--- a/templates/blog/_comment_form.html.twig
+++ b/templates/blog/_comment_form.html.twig
@@ -28,6 +28,7 @@
             {{ form_errors(form.content) }}
 
             {{ form_widget(form.content, {attr: {rows: 10}}) }}
+            {{ form_help(form.content) }}
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
One of my favourite new Symfony 4.1 features. It's amazing and it looks like this in the Demo app:

![form-help](https://user-images.githubusercontent.com/73419/41594526-fa670158-73c3-11e8-9044-3cf8a2f6a26d.png)
