### PR TITLE
Add missing but unused logic to PostVoter

### DIFF
--- a/src/Security/PostVoter.php
+++ b/src/Security/PostVoter.php
@@ -46,6 +46,11 @@ class PostVoter extends Voter
      */
     protected function voteOnAttribute($attribute, $post, TokenInterface $token): bool
     {
+        // all users are allowed to view posts
+        if (self::SHOW === $attribute) {
+            return true;
+        }
+
         $user = $token->getUser();
 
         // the user must be logged in; if not, deny permission


### PR DESCRIPTION
Adds a small bit of code to accommodate the missing logic when trying to view other users' posts. Although the demo never triggers any security checks when trying to view a post, the class describes this attribute itself, so I figured we might as well add it.