### PR TITLE
Fix installation when using composer 1.7+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "sensiolabs/security-checker": "^4.1",
         "symfony/asset": "^4.1",
         "symfony/expression-language": "^4.1",
-        "symfony/flex": "^1.0",
+        "symfony/flex": "^1.0.86",
         "symfony/form": "^4.1",
         "symfony/framework-bundle": "^4.1",
         "symfony/monolog-bundle": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7528d6e1a96f81aa7d082ecd8cb0653d",
+    "content-hash": "a53c22eb2fd33555f2170df1de5981fe",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2491,16 +2491,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.0.83",
+            "version": "v1.0.89",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "ec42e791e12ca37d73ac37dd8744ef763d39dbbe"
+                "reference": "26be754f42c3c3f21139af2bdd74118ef8f82757"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/ec42e791e12ca37d73ac37dd8744ef763d39dbbe",
-                "reference": "ec42e791e12ca37d73ac37dd8744ef763d39dbbe",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/26be754f42c3c3f21139af2bdd74118ef8f82757",
+                "reference": "26be754f42c3c3f21139af2bdd74118ef8f82757",
                 "shasum": ""
             },
             "require": {
@@ -2534,7 +2534,7 @@
                 }
             ],
             "description": "Composer plugin for Symfony",
-            "time": "2018-07-13T07:56:08+00:00"
+            "time": "2018-07-29T16:20:30+00:00"
         },
         {
             "name": "symfony/form",


### PR DESCRIPTION
This avoid the following error while installing the demo application with composer 1.7.

```
Declaration of Symfony\Flex\ParallelDownloader::getRemoteContents($originUrl, $fileUrl, $context) should be compatible with Composer\Util\RemoteFilesystem::getRemoteContents
  ($originUrl, $fileUrl, $context, ?array &$responseHeaders = NULL)
```