### PR TITLE
Adding missed post-install-cmd script section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,13 @@
             "cache:clear": "symfony-cmd",
             "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd",
             "security-checker security:check": "script"
-        }
+        },
+        "post-install-cmd": [
+            "@auto-scripts"
+        ],
+        "post-update-cmd": [
+            "@auto-scripts"
+        ]
     },
     "conflict": {
         "symfony/symfony": "*"


### PR DESCRIPTION
Adding missed post-install-cmd/post-update-cmd under script section in composer.json
Fixes #842 