### PR TITLE
Fix /var configuration in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ yarn-error.log
 ###> symfony/framework-bundle ###
 /.env
 /public/bundles/
-/var/
 /vendor/
 ###< symfony/framework-bundle ###
 


### PR DESCRIPTION
A better fix would probably be to move the DB elsewhere.

But at least, this change is required to make the demo work out of the box. If not, the `var/` directory is not added when doing `git add .` after creating the project with `composer create-project`, which is not what we want.