### PR TITLE
Fixed the has_role() deprecation

### DIFF
--- a/src/Controller/Admin/BlogController.php
+++ b/src/Controller/Admin/BlogController.php
@@ -33,7 +33,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * See http://knpbundles.com/keyword/admin
  *
  * @Route("/admin/post")
- * @Security("has_role('ROLE_ADMIN')")
+ * @Security("is_granted('ROLE_ADMIN')")
  *
  * @author Ryan Weaver <weaverryan@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
  * Controller used to manage current user.
  *
  * @Route("/profile")
- * @Security("has_role('ROLE_USER')")
+ * @Security("is_granted('ROLE_USER')")
  *
  * @author Romain Monteil <monteil.romain@gmail.com>
  */


### PR DESCRIPTION
This is a deprecation introduced by the upgrade to Symfony 4.2 in #865.

```
14x: Using the "has_role()" function in security expressions is deprecated since Symfony 4.2, use "is_granted()" instead.
    2x in BlogControllerTest::testAdminNewPost from App\Tests\Controller\Admin
    2x in BlogControllerTest::testAdminEditPost from App\Tests\Controller\Admin
    2x in BlogControllerTest::testAdminDeletePost from App\Tests\Controller\Admin
    2x in UserControllerTest::testAccessDeniedForAnonymousUsers from App\Tests\Controller
    2x in UserControllerTest::testEditUser from App\Tests\Controller
    2x in UserControllerTest::testChangePassword from App\Tests\Controller
    1x in BlogControllerTest::testAdminBackendHomePage from App\Tests\Controller\Admin
    1x in BlogControllerTest::testAdminShowPost from App\Tests\Controller\Admin
```