### PR TITLE
Fixed the DateTime constraint deprecation

### DIFF
--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -64,7 +64,6 @@ class Comment
      * @var \DateTime
      *
      * @ORM\Column(type="datetime")
-     * @Assert\DateTime
      */
     private $publishedAt;
 

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -87,7 +87,6 @@ class Post
      * @var \DateTime
      *
      * @ORM\Column(type="datetime")
-     * @Assert\DateTime
      */
     private $publishedAt;
 


### PR DESCRIPTION
This is a deprecation introduced by the upgrade to Symfony 4.2 in #865.

```
3x: Validating a \DateTimeInterface with "Symfony\Component\Validator\Constraints\DateTime" is deprecated since version 4.2. Use "Symfony\Component\Validator\Constraints\Type" instead or remove the constraint if the underlying model is already type hinted to \DateTimeInterface.
    1x in BlogControllerTest::testAdminNewPost from App\Tests\Controller\Admin
    1x in BlogControllerTest::testAdminEditPost from App\Tests\Controller\Admin
    1x in BlogControllerTest::testNewComment from App\Tests\Controller
```