### PR TITLE
Fix DateTimePicker widget

### DIFF
--- a/src/Form/Type/DateTimePickerType.php
+++ b/src/Form/Type/DateTimePickerType.php
@@ -51,6 +51,7 @@ class DateTimePickerType extends AbstractType
     {
         $resolver->setDefaults([
             'widget' => 'single_text',
+            'html5' => false,
         ]);
     }
 


### PR DESCRIPTION
As spotted here https://github.com/symfony/symfony/pull/28723#issuecomment-431286197 we need to disable `html5` to use a `type="text"` input again and make it work.

| before | after |
| --- | --- |
| ![wrong_datepicker](https://user-images.githubusercontent.com/2028198/47217570-d05a9880-d376-11e8-9e3a-116769569f22.png) | ![correct_datepicker](https://user-images.githubusercontent.com/2028198/47217582-d6e91000-d376-11e8-9fb7-86384c57ebbb.png) |

