### PR TITLE
Delete duplicate sensio_framework_extra config

### DIFF
--- a/config/packages/framework_extra.yaml
+++ b/config/packages/framework_extra.yaml
@@ -1,3 +1,0 @@
-sensio_framework_extra:
-    router:
-        annotations: false


### PR DESCRIPTION
It exists already as https://github.com/symfony/demo/blob/bbe5180a8c3b6886ea59227df83de59a4573e586/config/packages/sensio_framework_extra.yaml