### PR TITLE
Remove default private services config

### DIFF
--- a/config/packages/prod/framework.yaml
+++ b/config/packages/prod/framework.yaml
@@ -1,3 +1,0 @@
-#framework:
-#    cache:
-#        system: cache.adapter.apcu

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,9 +11,6 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
-        public: false       # Allows optimizing the container by removing unused services; this also means
-                            # fetching services directly from the container via $container->get() won't work.
-                            # The best practice is to be explicit about your dependencies anyway.
         bind:               # defines the scalar arguments once and apply them to any service defined/created in this file
             $locales: '%app_locales%'
             $defaultLocale: '%locale%'


### PR DESCRIPTION
- the system cache uses apcu automatically when available, see https://github.com/symfony/symfony/blob/2bfcaeb31ff3b878734b0951851d25abf2b3321e/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php#L109

- private services are the default now, see symfony/recipes@4c3d490