### PR TITLE
removed md2html from summary on blog index template

### DIFF
--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -16,7 +16,7 @@
                 <span class="metadata"><i class="fa fa-user"></i> {{ post.author.fullName }}</span>
             </p>
 
-            {{ post.summary|md2html }}
+            {{ post.summary }}
 
             {{ include('blog/_post_tags.html.twig') }}
         </article>


### PR DESCRIPTION
The description says that neither HTML nor Markdown is allowed. This is also the only place where markdown is interpreted on the summary.