### PR TITLE
Require php-intl instead of crashing on IntlTimeZone

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-pdo_sqlite": "*",
+        "ext-intl": "*",
         "doctrine/doctrine-bundle": "^1.6.10",
         "doctrine/doctrine-migrations-bundle": "^1.3",
         "doctrine/orm": "^2.5.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bc0ee1d8d75721882a25b75eddb6944",
+    "content-hash": "218c6a2d6482496fef19e380ccf5e56f",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -6204,7 +6204,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.1.3",
-        "ext-pdo_sqlite": "*"
+        "ext-pdo_sqlite": "*",
+        "ext-intl": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
PHP 7.2 on Ubuntu does not have `php7.2-intl` installed by default.
With `composer install` there are no check for **`intl`** extension
and first page shows misleading error:

![Attempted to load class "IntlTimeZone" from the global namespace. Did you forget a "use" statement?](https://user-images.githubusercontent.com/1453957/48369076-2a245900-e6be-11e8-9f6d-bfc441dc5760.jpeg)


It is better to show warning during `composer install`
(or composer create-project):

![Your requirements could not be resolved to an installable set of packages. Problem 1 - The requested PHP extension ext-intl * is missing from your system. Install or enable PHP's intl extension.](https://user-images.githubusercontent.com/1453957/48369090-37d9de80-e6be-11e8-904a-93ae40c3be56.jpg)

So it would be **easier to google**, that the original problem could be solved with:

```bash
sudo apt-get install php7.2-intl
```