### PR TITLE
Disable HTTP caching for the pages where flashes are being shown

### DIFF
--- a/src/EventSubscriber/DisableHttpCachingSubscriber.php
+++ b/src/EventSubscriber/DisableHttpCachingSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Disables HTTP caching.
+ *
+ * @author Oleg Voronkovich <oleg-voronkovich@yandex.ru>
+ */
+class DisableHttpCachingSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var bool
+     */
+    private $disableHttpCaching = false;
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // See https://symfony.com/doc/current/components/http_kernel.html#the-kernel-response-event
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+
+    public function disableHttpCaching(): void
+    {
+        $this->disableHttpCaching = true;
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event): void
+    {
+        if (!$event->isMasterRequest() || !$this->disableHttpCaching) {
+            return;
+        }
+
+        // See https://tools.ietf.org/html/rfc7234#section-5.2.1.5
+        $event->getResponse()->headers->addCacheControlDirective('no-store');
+    }
+}

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -11,6 +11,7 @@
 
 namespace App\Twig;
 
+use App\EventSubscriber\DisableHttpCachingSubscriber;
 use App\Utils\Markdown;
 use Symfony\Component\Intl\Intl;
 use Twig\Extension\AbstractExtension;
@@ -32,11 +33,13 @@ class AppExtension extends AbstractExtension
     private $parser;
     private $localeCodes;
     private $locales;
+    private $httpCaching;
 
-    public function __construct(Markdown $parser, string $locales)
+    public function __construct(Markdown $parser, string $locales, DisableHttpCachingSubscriber $httpCaching)
     {
         $this->parser = $parser;
         $this->localeCodes = explode('|', $locales);
+        $this->httpCaching = $httpCaching;
     }
 
     /**
@@ -56,6 +59,7 @@ class AppExtension extends AbstractExtension
     {
         return [
             new TwigFunction('locales', [$this, 'getLocales']),
+            new TwigFunction('disable_http_caching', [$this, 'disableHttpCaching']),
         ];
     }
 
@@ -84,5 +88,10 @@ class AppExtension extends AbstractExtension
         }
 
         return $this->locales;
+    }
+
+    public function disableHttpCaching(): void
+    {
+        $this->httpCaching->disableHttpCaching();
     }
 }

--- a/templates/default/_flash_messages.html.twig
+++ b/templates/default/_flash_messages.html.twig
@@ -8,13 +8,18 @@
 #}
 
 {#
-   The request method check is needed to prevent starting the session when looking for "flash messages":
-   https://symfony.com/doc/current/session/avoid_session_start.html
+   We need to disalbe HTTP caching for the pages where flashes are being shown
 
    TIP: With FOSHttpCache you can also adapt this to make it cache safe:
    https://foshttpcachebundle.readthedocs.io/en/latest/features/helpers/flash-message.html
 #}
-{% if app.request.method == 'POST' %}
+{{ disable_http_caching() }}
+
+{#
+   This check is needed to prevent starting the session when looking for "flash messages":
+   https://symfony.com/doc/current/session/avoid_session_start.html
+#}
+{% if app.request.hasPreviousSession %}
     <div class="messages">
         {% for type, messages in app.flashes %}
             {% for message in messages %}


### PR DESCRIPTION
For now demo app shows flashes only when an HTTP method POST is used to avoid page caching. Maybe we could fix it by adding [no-store](https://tools.ietf.org/html/rfc7234#section-5.2.1.5) directive for all pages where the flashes are being shown?