### PR TITLE
Fix translations files with ICU message formater

### DIFF
--- a/translations/messages+intl-icu.bg.xlf
+++ b/translations/messages+intl-icu.bg.xlf
@@ -20,15 +20,15 @@
             </trans-unit>
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Грешка %status_code%</target>
+                <target>Грешка {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Има неизвестна грешка (HTTP %status_code%) , която спира изпълнението на заявката.</target>
+                <target>Има неизвестна грешка (HTTP {status_code, number}) , която спира изпълнението на заявката.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Опитайте да заредите тази страница няколко минути по-късно или <a href="%url%">се върни в началната страница</a>.]]></target>
+                <target><![CDATA[Опитайте да заредите тази страница няколко минути по-късно или <a href="{url}">се върни в началната страница</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -44,7 +44,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Проверете за правописни грешки в URL адреса или <a href="%url%">се върнете в началната страница</a>.]]></target>
+                <target><![CDATA[Проверете за правописни грешки в URL адреса или <a href="{url}">се върнете в началната страница</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -52,7 +52,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Опитайте да заредите тази страница отново след няколко минути или <a href="%url%">се върнете в началната страница</a>.]]></target>
+                <target><![CDATA[Опитайте да заредите тази страница отново след няколко минути или <a href="{url}">се върнете в началната страница</a>.]]></target>
             </trans-unit>
             <trans-unit id="title.homepage">
                 <source>title.homepage</source>
@@ -80,7 +80,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Редактиране на публикация #%id%</target>
+                <target>Редактиране на публикация #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -300,7 +300,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Вашата публикация "%title%" получи нов коментар. Можете да прочетете коментара, като последвате <a href="%link%">този линк</a>]]></target>
+                <target><![CDATA[Вашата публикация "{title}" получи нов коментар. Можете да прочетете коментара, като последвате <a href="{link}">този линк</a>]]></target>
             </trans-unit>
             <trans-unit id="help.app_description">
                 <source>help.app_description</source>

--- a/translations/messages+intl-icu.ca.xlf
+++ b/translations/messages+intl-icu.ca.xlf
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Editar article #%id%</target>
+                <target>Editar article #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>

--- a/translations/messages+intl-icu.cs.xlf
+++ b/translations/messages+intl-icu.cs.xlf
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Upravit příspěvek #%id%</target>
+                <target>Upravit příspěvek #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>

--- a/translations/messages+intl-icu.de.xlf
+++ b/translations/messages+intl-icu.de.xlf
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Bearbeite Beitrag #%id%</target>
+                <target>Bearbeite Beitrag #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -310,15 +310,15 @@
             </trans-unit>
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Fehler %status_code%</target>
+                <target>Fehler {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Ein unbekannter Fehler (HTTP %status_code%) ist aufgetreten. Deine Anfrage konnte deswegen nicht ausgeführt werden.</target>
+                <target>Ein unbekannter Fehler (HTTP {status_code, number}) ist aufgetreten. Deine Anfrage konnte deswegen nicht ausgeführt werden.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Versuche diese Seite in einigen Minuten erneut zu laden oder <a href="%url%">gehe zurück zur Homepage</a>.]]></target>
+                <target><![CDATA[Versuche diese Seite in einigen Minuten erneut zu laden oder <a href="{url}">gehe zurück zur Homepage</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -334,7 +334,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Überprüfe Rechtschreibfehler in der URL oder <a href="%url%">gehe zurück zur Homepage</a>.]]></target>
+                <target><![CDATA[Überprüfe Rechtschreibfehler in der URL oder <a href="{url}">gehe zurück zur Homepage</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -342,7 +342,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Versuche diese Seite in einigen Minuten erneut zu laden oder <a href="%url%">gehe zurück zur Homepage</a>.]]></target>
+                <target><![CDATA[Versuche diese Seite in einigen Minuten erneut zu laden oder <a href="{url}">gehe zurück zur Homepage</a>.]]></target>
             </trans-unit>
             <trans-unit id="notification.comment_created">
                 <source>notification.comment_created</source>
@@ -350,7 +350,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Dein Beitrag "%title%" hat einen Kommentar erhalten. Du kannst den Kommentar lesen, wenn du <a href="%link%">diesem Link</a> folgst.]]></target>
+                <target><![CDATA[Dein Beitrag "{title}" hat einen Kommentar erhalten. Du kannst den Kommentar lesen, wenn du <a href="{link}">diesem Link</a> folgst.]]></target>
             </trans-unit>
         </body>
     </file>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Error %status_code%</target>
+                <target>Error {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>There was an unknown error (HTTP %status_code%) that prevented to complete your request.</target>
+                <target>There was an unknown error (HTTP {status_code, number}) that prevented to complete your request.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Try loading this page again in some minutes or <a href="%url%">go back to the homepage</a>.]]></target>
+                <target><![CDATA[Try loading this page again in some minutes or <a href="{url}">go back to the homepage</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Check out any misspelling in the URL or <a href="%url%">go back to the homepage</a>.]]></target>
+                <target><![CDATA[Check out any misspelling in the URL or <a href="{url}">go back to the homepage</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Try loading this page again in some minutes or <a href="%url%">go back to the homepage</a>.]]></target>
+                <target><![CDATA[Try loading this page again in some minutes or <a href="{url}">go back to the homepage</a>.]]></target>
             </trans-unit>
 
             <trans-unit id="title.homepage">
@@ -82,7 +82,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Edit post #%id%</target>
+                <target>Edit post #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -352,7 +352,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Your post "%title%" has received a new comment. You can read the comment by following <a href="%link%">this link</a>]]></target>
+                <target><![CDATA[Your post "{title}" has received a new comment. You can read the comment by following <a href="{link}">this link</a>]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.es.xlf
+++ b/translations/messages+intl-icu.es.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Error %status_code%</target>
+                <target>Error {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Se ha producido un error desconocido (HTTP %status_code%) que ha impedido completar tu petición.</target>
+                <target>Se ha producido un error desconocido (HTTP {status_code, number}) que ha impedido completar tu petición.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Intentar recargar esta página dentro de unos minutos o <a href="%url%">vuelve a la portada del sitio</a>.]]></target>
+                <target><![CDATA[Intentar recargar esta página dentro de unos minutos o <a href="{url}">vuelve a la portada del sitio</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Comprueba que la dirección de la página está bien escrita o <a href="%url%">vuelve a la portada del sitio</a>.]]></target>
+                <target><![CDATA[Comprueba que la dirección de la página está bien escrita o <a href="{url}">vuelve a la portada del sitio</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Intentar recargar esta página dentro de unos minutos o <a href="%url%">vuelve a la portada del sitio</a>.]]></target>
+                <target><![CDATA[Intentar recargar esta página dentro de unos minutos o <a href="{url}">vuelve a la portada del sitio</a>.]]></target>
             </trans-unit>
 
             <trans-unit id="title.homepage">
@@ -82,7 +82,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Editar artículo #%id%</target>
+                <target>Editar artículo #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -347,7 +347,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Su artículo "%title%" recibió un comentario nuevo. Puede leer el comentario siguiendo <a href="%link%">este enlace</a>]]></target>
+                <target><![CDATA[Su artículo "{title}" recibió un comentario nuevo. Puede leer el comentario siguiendo <a href="{link}">este enlace</a>]]></target>
             </trans-unit>
             <trans-unit id="rss.title">
                 <source>rss.title</source>

--- a/translations/messages+intl-icu.fr.xlf
+++ b/translations/messages+intl-icu.fr.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Erreur %status_code%</target>
+                <target>Erreur {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Il y a eu une erreur inconnue (HTTP %status_code%) qui a empêché l'aboutissement de votre requête.</target>
+                <target>Il y a eu une erreur inconnue (HTTP {status_code, number}) qui a empêché l'aboutissement de votre requête.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Essayez de recharger cette page dans quelques minutes ou <a href="%url%">retournez sur la page principale</a>.]]></target>
+                <target><![CDATA[Essayez de recharger cette page dans quelques minutes ou <a href="{url}">retournez sur la page principale</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Vérifiez si l'URL ne comporte pas d'erreurs ou <a href="%url%">retournez sur la page principale</a>.]]></target>
+                <target><![CDATA[Vérifiez si l'URL ne comporte pas d'erreurs ou <a href="{url}">retournez sur la page principale</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Essayez de recharger cette page dans quelques minutes ou <a href="%url%">retournez sur la page principale</a>.]]></target>
+                <target><![CDATA[Essayez de recharger cette page dans quelques minutes ou <a href="{url}">retournez sur la page principale</a>.]]></target>
             </trans-unit>
 
             <trans-unit id="title.homepage">
@@ -82,7 +82,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Modifier l'article #%id%</target>
+                <target>Modifier l'article #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -352,7 +352,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Votre article "%title%" a reçu un nouveau commentaire. Vous pouvez lire le commentaire en suivant <a href="%link%">ce lien</a>]]></target>
+                <target><![CDATA[Votre article "{title}" a reçu un nouveau commentaire. Vous pouvez lire le commentaire en suivant <a href="{link}">ce lien</a>]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.hr.xlf
+++ b/translations/messages+intl-icu.hr.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Greška %status_code%</target>
+                <target>Greška {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Desila se nepoznata greška (HTTP %status_code%), koja je spriječila završetak zahtjeva.</target>
+                <target>Desila se nepoznata greška (HTTP {status_code, number}), koja je spriječila završetak zahtjeva.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Pokušajte ponovno učitati stranicu nakon nekoliko minuta ili <a href="%url%">se vratite na početnu stranicu</a>.]]></target>
+                <target><![CDATA[Pokušajte ponovno učitati stranicu nakon nekoliko minuta ili <a href="{url}">se vratite na početnu stranicu</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Provjerite ima li pravopisne greške unutar URL adrese ili <a href="%url%">se vratite na početnu stranicu</a>.]]></target>
+                <target><![CDATA[Provjerite ima li pravopisne greške unutar URL adrese ili <a href="{url}">se vratite na početnu stranicu</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Pokušajte ponovno učitati stranicu nakon nekoliko minuta ili <a href="%url%">se vratite na početnu stranicu</a>.]]></target>
+                <target><![CDATA[Pokušajte ponovno učitati stranicu nakon nekoliko minuta ili <a href="{url}">se vratite na početnu stranicu</a>.]]></target>
             </trans-unit>
             <trans-unit id="title.homepage">
                 <source>title.homepage</source>
@@ -81,7 +81,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Uredi članak #%id%</target>
+                <target>Uredi članak #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -287,7 +287,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Vaš članak "%title%" je komentiran. Možete pročitati komentar prateći <a href="%link%">ovu poveznicu</a>]]></target>
+                <target><![CDATA[Vaš članak "{title}" je komentiran. Možete pročitati komentar prateći <a href="{link}">ovu poveznicu</a>]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.id.xlf
+++ b/translations/messages+intl-icu.id.xlf
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Sunting posting #%id%</target>
+                <target>Sunting posting #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>

--- a/translations/messages+intl-icu.it.xlf
+++ b/translations/messages+intl-icu.it.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Errore %status_code%</target>
+                <target>Errore {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Un errore sconosciuto (HTTP %status_code%) ha impedito di completare la richiesta.</target>
+                <target>Un errore sconosciuto (HTTP {status_code, number}) ha impedito di completare la richiesta.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Provare a ricaricare la pagina tra poco o <a href="%url%">tornare alla homepage</a>.]]></target>
+                <target><![CDATA[Provare a ricaricare la pagina tra poco o <a href="{url}">tornare alla homepage</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Verificare di aver scritto correttamente l'URL o <a href="%url%">tornare alla homepage</a>.]]></target>
+                <target><![CDATA[Verificare di aver scritto correttamente l'URL o <a href="{url}">tornare alla homepage</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Provare a ricaricare la pagina tra poco o <a href="%url%">tornare alla homepage</a>.]]></target>
+                <target><![CDATA[Provare a ricaricare la pagina tra poco o <a href="{url}">tornare alla homepage</a>.]]></target>
             </trans-unit>
 
             <trans-unit id="title.homepage">
@@ -82,7 +82,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Modifica post #%id%</target>
+                <target>Modifica post #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -307,7 +307,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Il post "%title%" ha ricevuto un nuovo commento. Si può leggere il commento al seguente <a href="%link%">collegamento</a>]]></target>
+                <target><![CDATA[Il post "{title}" ha ricevuto un nuovo commento. Si può leggere il commento al seguente <a href="{link}">collegamento</a>]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.ja.xlf
+++ b/translations/messages+intl-icu.ja.xlf
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>#%id% この記事を編集</target>
+                <target>#{id, number} この記事を編集</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -234,7 +234,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[あなたの投稿「%title%」に新しいコメントが届きました。<a href="%link%">このリンク</a>に沿ってコメントを読むことができます]]></target>
+                <target><![CDATA[あなたの投稿「{title}」に新しいコメントが届きました。<a href="{link}">このリンク</a>に沿ってコメントを読むことができます]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.nl.xlf
+++ b/translations/messages+intl-icu.nl.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Fout %status_code%</target>
+                <target>Fout {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Een onbekende fout (HTTP %status_code%) is opgetreden, waardoor de aanvraag niet gelukt is.</target>
+                <target>Een onbekende fout (HTTP {status_code, number}) is opgetreden, waardoor de aanvraag niet gelukt is.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Probeer de pagina over een paar minuten te herladen, of <a href="%url%">ga terug naar de beginpagina</a>.]]></target>
+                <target><![CDATA[Probeer de pagina over een paar minuten te herladen, of <a href="{url}">ga terug naar de beginpagina</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Controleer de URL op typefouten, of <a href="%url%">ga terug naar de beginpagina</a>.]]></target>
+                <target><![CDATA[Controleer de URL op typefouten, of <a href="{url}">ga terug naar de beginpagina</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Probeer de pagina over een paar minuten te herladen, of <a href="%url%">ga terug naar de beginpagina</a>.]]></target>
+                <target><![CDATA[Probeer de pagina over een paar minuten te herladen, of <a href="{url}">ga terug naar de beginpagina</a>.]]></target>
             </trans-unit>
             <trans-unit id="title.homepage">
                 <source>title.homepage</source>
@@ -81,7 +81,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Bewerk bericht #%id%</target>
+                <target>Bewerk bericht #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -307,7 +307,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Er is een nieuwe reactie bij je bericht "%title%"geplaatst. Je kunt de reactie lezen op <a href="%link%">deze link</a>]]></target>
+                <target><![CDATA[Er is een nieuwe reactie bij je bericht "{title}"geplaatst. Je kunt de reactie lezen op <a href="{link}">deze link</a>]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.pl.xlf
+++ b/translations/messages+intl-icu.pl.xlf
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Edytuj artykuł #%id%</target>
+                <target>Edytuj artykuł #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>

--- a/translations/messages+intl-icu.pt_BR.xlf
+++ b/translations/messages+intl-icu.pt_BR.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Erro %status_code%</target>
+                <target>Erro {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Ocorreu um erro desconhecido (HTTP %status_code%) que impediu a sua requisição de ser completada.</target>
+                <target>Ocorreu um erro desconhecido (HTTP {status_code, number}) que impediu a sua requisição de ser completada.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Tente carregar essa página novamente dentro de alguns minutos ou <a href="%url%">volte para a página inicial</a>.]]></target>
+                <target><![CDATA[Tente carregar essa página novamente dentro de alguns minutos ou <a href="{url}">volte para a página inicial</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Verifique erros de digitação na URL ou <a href="%url%">volte para a página inicial</a>.]]></target>
+                <target><![CDATA[Verifique erros de digitação na URL ou <a href="{url}">volte para a página inicial</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Tente carregar essa página novamente dentro de alguns minutos ou <a href="%url%">volte para a página inicial</a>.]]></target>
+                <target><![CDATA[Tente carregar essa página novamente dentro de alguns minutos ou <a href="{url}">volte para a página inicial</a>.]]></target>
             </trans-unit>
 
             <trans-unit id="title.homepage">
@@ -82,7 +82,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Editar o post #%id%</target>
+                <target>Editar o post #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -295,7 +295,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Seu post "%title%" recebeu um novo comentário. Você pode ler o comentário através <a href="%link%">deste link</a>]]></target>
+                <target><![CDATA[Seu post "{title}" recebeu um novo comentário. Você pode ler o comentário através <a href="{link}">deste link</a>]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.ro.xlf
+++ b/translations/messages+intl-icu.ro.xlf
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Modifică articolul #%id%</target>
+                <target>Modifică articolul #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>

--- a/translations/messages+intl-icu.ru.xlf
+++ b/translations/messages+intl-icu.ru.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Ошибка %status_code%</target>
+                <target>Ошибка {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Произошла неизвестная ошибка (HTTP %status_code%), которая помешала выполнить ваш запрос.</target>
+                <target>Произошла неизвестная ошибка (HTTP {status_code, number}), которая помешала выполнить ваш запрос.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Попробуйте загрузить эту страницу снова через несколько минут или <a href="%url%">вернитесь на главную страницу</a>.]]></target>
+                <target><![CDATA[Попробуйте загрузить эту страницу снова через несколько минут или <a href="{url}">вернитесь на главную страницу</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Проверьте корректность введенного URL или <a href="%url%">вернитесь на главную страницу</a>.]]></target>
+                <target><![CDATA[Проверьте корректность введенного URL или <a href="{url}">вернитесь на главную страницу</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Попробуйте загрузить эту страницу снова через несколько минут или <a href="%url%">вернитесь на главную страницу</a>.]]></target>
+                <target><![CDATA[Попробуйте загрузить эту страницу снова через несколько минут или <a href="{url}">вернитесь на главную страницу</a>.]]></target>
             </trans-unit>
 
             <trans-unit id="title.homepage">
@@ -82,7 +82,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Изменение записи #%id%</target>
+                <target>Изменение записи #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -347,7 +347,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Ваша запись "%title%" получила новый комментарий. Вы можете прочесть этот коментарий, перейдя по <a href="%link%">этой ссылке</a>]]></target>
+                <target><![CDATA[Ваша запись "{title}" получила новый комментарий. Вы можете прочесть этот коментарий, перейдя по <a href="{link}">этой ссылке</a>]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.sl.xlf
+++ b/translations/messages+intl-icu.sl.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Napaka %status_code%</target>
+                <target>Napaka {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Prišlo je do neznane napake (HTTP %status_code%), ki preprečuje zaključiti vaš zahtevek.</target>
+                <target>Prišlo je do neznane napake (HTTP {status_code, number}), ki preprečuje zaključiti vaš zahtevek.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Poskusite ponovno naložiti to stran čez nekaj minut ali pa <a href="%url%">se vrnite na domačo stran</a>.]]></target>
+                <target><![CDATA[Poskusite ponovno naložiti to stran čez nekaj minut ali pa <a href="{url}">se vrnite na domačo stran</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Preverite morebitne napake črkovanja v URL ali pa <a href="%url%">se vrnite na domačo stran</a>.]]></target>
+                <target><![CDATA[Preverite morebitne napake črkovanja v URL ali pa <a href="{url}">se vrnite na domačo stran</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Poskusite ponovno naložiti to stran čez nekaj minut ali pa <a href="%url%">se vrnite na domačo stran</a>.]]></target>
+                <target><![CDATA[Poskusite ponovno naložiti to stran čez nekaj minut ali pa <a href="{url}">se vrnite na domačo stran</a>.]]></target>
             </trans-unit>
 
             <trans-unit id="title.homepage">
@@ -82,7 +82,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Uredi objavo #%id%</target>
+                <target>Uredi objavo #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -307,7 +307,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Vaša objava "%title%" je prejela nov komentar. Preberete ga lahko na <a href="%link%">tej povezavi</a>]]></target>
+                <target><![CDATA[Vaša objava "{title}" je prejela nov komentar. Preberete ga lahko na <a href="{link}">tej povezavi</a>]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.tr.xlf
+++ b/translations/messages+intl-icu.tr.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Hata %status_code%</target>
+                <target>Hata {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>İsteğinizi tamamlamayı engelleyen bilinmeyen bir hata oluştu (HTTP% status_code%).</target>
+                <target>İsteğinizi tamamlamayı engelleyen bilinmeyen bir hata oluştu (HTTP {status_code}).</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Bu sayfayı birkaç dakika içinde tekrar yüklemeyi veya <a href="%url%">ana sayfaya geri dönmeyi</a> deneyin.]]></target>
+                <target><![CDATA[Bu sayfayı birkaç dakika içinde tekrar yüklemeyi veya <a href="{url}">ana sayfaya geri dönmeyi</a> deneyin.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[URL'de yanlış yazımları kontrol edin veya <a href="%url%">ana sayfaya geri dönün</a>.]]></target>
+                <target><![CDATA[URL'de yanlış yazımları kontrol edin veya <a href="{url}">ana sayfaya geri dönün</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Bu sayfayı birkaç dakika içinde tekrar yüklemeyi veya <a href="%url%">ana sayfaya geri dönmeyi</a> deneyin.]]></target>
+                <target><![CDATA[Bu sayfayı birkaç dakika içinde tekrar yüklemeyi veya <a href="{url}">ana sayfaya geri dönmeyi</a> deneyin.]]></target>
             </trans-unit>
 
             <trans-unit id="title.homepage">
@@ -82,7 +82,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Gönderiyi düzenle #%id%</target>
+                <target>Gönderiyi düzenle #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -307,7 +307,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Gönderiniz "% title%" yeni bir yorum aldı. Yorumu <a href="%link%">bu bağlantıyı</a> takip ederek okuyabilirsiniz.]]></target>
+                <target><![CDATA[Gönderiniz "{title}" yeni bir yorum aldı. Yorumu <a href="{link}">bu bağlantıyı</a> takip ederek okuyabilirsiniz.]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.uk.xlf
+++ b/translations/messages+intl-icu.uk.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>Помилка %status_code%</target>
+                <target>Помилка {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Виникла невідма помилка (HTTP %status_code%), котра завадила виконати ваш запит.</target>
+                <target>Виникла невідма помилка (HTTP {status_code, number}), котра завадила виконати ваш запит.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[Спробуйте завантажити цю сторінку знову через декілька хвилин або <a href="%url%">поверніться на головну сторінку</a>.]]></target>
+                <target><![CDATA[Спробуйте завантажити цю сторінку знову через декілька хвилин або <a href="{url}">поверніться на головну сторінку</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[Перевірте коректність введеного URL або <a href="%url%">поверніться на головну сторінку</a>.]]></target>
+                <target><![CDATA[Перевірте коректність введеного URL або <a href="{url}">поверніться на головну сторінку</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[Спробуйте завантажити цю сторінку знову через декілька хвилин або <a href="%url%">поверніться на головну сторінку</a>.]]></target>
+                <target><![CDATA[Спробуйте завантажити цю сторінку знову через декілька хвилин або <a href="{url}">поверніться на головну сторінку</a>.]]></target>
             </trans-unit>
 
             <trans-unit id="title.homepage">
@@ -82,7 +82,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>Редагування запису #%id%</target>
+                <target>Редагування запису #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -307,7 +307,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[Ваш запис "%title%" отримав новий коментар. Ви можете прочитати цей коментар, перейшовши за <a href="%link%">цим посиланням</a>]]></target>
+                <target><![CDATA[Ваш запис "{title}" отримав новий коментар. Ви можете прочитати цей коментар, перейшовши за <a href="{link}">цим посиланням</a>]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">

--- a/translations/messages+intl-icu.zh_CN.xlf
+++ b/translations/messages+intl-icu.zh_CN.xlf
@@ -21,15 +21,15 @@
 
             <trans-unit id="http_error.name">
                 <source>http_error.name</source>
-                <target>错误 %status_code%</target>
+                <target>错误 {status_code, number}</target>
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>有未知错误 (HTTP %status_code%) 阻止你的请求.</target>
+                <target>有未知错误 (HTTP {status_code, number}) 阻止你的请求.</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
-                <target><![CDATA[尝试在几分钟后重新加载此页或者 <a href="%url%">返回首页</a>.]]></target>
+                <target><![CDATA[尝试在几分钟后重新加载此页或者 <a href="{url}">返回首页</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
@@ -45,7 +45,7 @@
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target><![CDATA[请检查链接中的拼写错误或者 <a href="%url%">返回首页</a>.]]></target>
+                <target><![CDATA[请检查链接中的拼写错误或者 <a href="{url}">返回首页</a>.]]></target>
             </trans-unit>
             <trans-unit id="http_error_500.description">
                 <source>http_error_500.description</source>
@@ -53,7 +53,7 @@
             </trans-unit>
             <trans-unit id="http_error_500.suggestion">
                 <source>http_error_500.suggestion</source>
-                <target><![CDATA[尝试在几分钟后重新加载此页或者 <a href="%url%">返回首页</a>.]]></target>
+                <target><![CDATA[尝试在几分钟后重新加载此页或者 <a href="{url}">返回首页</a>.]]></target>
             </trans-unit>
 
             <trans-unit id="title.homepage">
@@ -82,7 +82,7 @@
             </trans-unit>
             <trans-unit id="title.edit_post">
                 <source>title.edit_post</source>
-                <target>编辑文章 #%id%</target>
+                <target>编辑文章 #{id, number}</target>
             </trans-unit>
             <trans-unit id="title.add_comment">
                 <source>title.add_comment</source>
@@ -295,7 +295,7 @@
             </trans-unit>
             <trans-unit id="notification.comment_created.description">
                 <source>notification.comment_created.description</source>
-                <target><![CDATA[你的文章 "%title%" 收到一条新评论. <a href="%link%">查看评论</a>]]></target>
+                <target><![CDATA[你的文章 "{title}" 收到一条新评论. <a href="{link}">查看评论</a>]]></target>
             </trans-unit>
 
             <trans-unit id="help.app_description">


### PR DESCRIPTION
As pointed by @stof in #890, translations files does no longer take in account variables because of the `+intl-icu` suffix in translation files. This PR fix that!