### PR TITLE
Temporary fix for the styles of the error 500 page

### DIFF
--- a/templates/bundles/TwigBundle/Exception/error500.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error500.html.twig
@@ -10,6 +10,11 @@
 
 {% extends 'base.html.twig' %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="/build/css/app.4aa95248.css">
+{% endblock %}
+
 {% block body_id 'error' %}
 
 {% block main %}


### PR DESCRIPTION
I know this is not the right fix ... but I can't fix it in any other way.

The error: if you comment the DATABASE_URL config in the .env file, you see a 500 error. In production, that 500 error page sometimes has CSS styles and sometimes hasn't. Example:

* This page shows styles: http://symfony-demo.test/index.php/en/blog/posts/lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit
* This page doesn't: http://symfony-demo.test/index.php/en/blog/

This is just a temporary fix because we need the Symfony Demo to work perfectly for some SymfonyCon session.