### PR TITLE
Use bootstrap.php for tests and environment-specific settings

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,8 @@
 # Set variables here that may be different on each deployment target of the app, e.g. development, staging, production.
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
+DEFAULT_FORMAT=xml
+
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_DEBUG=1

--- a/.env
+++ b/.env
@@ -2,8 +2,6 @@
 # Set variables here that may be different on each deployment target of the app, e.g. development, staging, production.
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
-DEFAULT_FORMAT=xml
-
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_DEBUG=1

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,3 @@
+# This file will be loaded after .env file and override environment
+# variables for your test environment.
+DATABASE_URL=sqlite:///%kernel.project_dir%/data/database_test.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,11 @@
-/var/*
-!/var/cache
-/var/cache/*
-!var/cache/.gitkeep
-!/var/data
-!/var/log
-/var/log/*
-!var/log/.gitkeep
-!/var/sessions
-/var/sessions/*
-!var/sessions/.gitkeep
 /public/build/fonts/glyphicons-*
 /public/build/images/glyphicons-*
 
 ###> symfony/framework-bundle ###
-/.env
+/.env.local
+/.env.*.local
 /public/bundles/
+/var/
 /vendor/
 ###< symfony/framework-bundle ###
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,29 +5,13 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="config/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="KERNEL_CLASS" value="App\Kernel" />
         <env name="SYMFONY_PHPUNIT_VERSION" value="7.1"/>
-        <!-- define your env variables for the test env here -->
-
-        <!-- ###+ doctrine/doctrine-bundle ### -->
-        <env name="DATABASE_URL" value="sqlite:///data/database_test.sqlite"/>
-        <!-- ###- doctrine/doctrine-bundle ### -->
-
-        <!-- ###+ symfony/swiftmailer-bundle ### -->
-        <env name="MAILER_URL" value="null://localhost"/>
-        <!-- ###- symfony/swiftmailer-bundle ### -->
-
-        <!-- ###+ symfony/framework-bundle ### -->
         <env name="APP_ENV" value="test"/>
-        <env name="APP_DEBUG" value="1"/>
-        <env name="APP_SECRET" value="5a79a1c866efef9ca1800f971d689f3e"/>
-        <!-- env name="TRUSTED_PROXIES" value="127.0.0.1,127.0.0.2" -->
-        <!-- env name="TRUSTED_HOSTS" value="localhost,example.com" -->
-        <!-- ###- symfony/framework-bundle ### -->
     </php>
 
     <testsuites>


### PR DESCRIPTION
Latest changes according to:
 * https://symfony.com/doc/current/configuration/dot-env-changes.html
 * https://symfony.com/blog/new-in-symfony-4-2-define-env-vars-per-environment
 * https://symfony.com/blog/improvements-to-the-handling-of-env-files-for-all-symfony-versions
 * and [phpunit recipe](https://github.com/symfony/recipes/blob/6c6ac5bf41c4952e1eeb2bdd2644ca2b4d8ba594/phpunit/phpunit/4.7/phpunit.xml.dist#L8)