### PR TITLE
Update error500.html.twig

### DIFF
--- a/templates/bundles/TwigBundle/Exception/error500.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error500.html.twig
@@ -12,7 +12,6 @@
 
 {% block stylesheets %}
     {{ parent() }}
-    <link rel="stylesheet" href="/build/css/app.4aa95248.css">
 {% endblock %}
 
 {% block body_id 'error' %}


### PR DESCRIPTION
Useless, already included with ```{{encore_entry_link_tags ('css / app')}}```