### PR TITLE
Fix dynamic translation with ICU

### DIFF
--- a/translations/validators+intl-icu.bg.xlf
+++ b/translations/validators+intl-icu.bg.xlf
@@ -12,11 +12,11 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Съдержанието на публикацията е прекалено малко ({{ limit }} минимум символа)</target>
+                <target>Съдержанието на публикацията е прекалено малко ({ limit } минимум символа)</target>
             </trans-unit>
             <trans-unit id="post.too_many_tags">
                 <source>post.too_many_tags</source>
-                <target>Прекалено много тагове (добави {{ limit }} тага или по-малко)</target>
+                <target>Прекалено много тагове (добави { limit } тага или по-малко)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Коментара е пркалено кратък ({{ limit }} симвала минимум)</target>
+                <target>Коментара е пркалено кратък ({ limit } симвала минимум)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Коментара е прекалено дълъг ({{ limit }} симвала максимум)</target>
+                <target>Коментара е прекалено дълъг ({ limit } симвала максимум)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.ca.xlf
+++ b/translations/validators+intl-icu.ca.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>El contingut de l'article és massa curt ({{ limit }} caràcters com a mínim)</target>
+                <target>El contingut de l'article és massa curt ({ limit } caràcters com a mínim)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>El comentari és massa curt ({{ limit }} caràcters com a mínim)</target>
+                <target>El comentari és massa curt ({ limit } caràcters com a mínim)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>El comentari és massa llarg ({{ limit }} caràcters com a màxim)</target>
+                <target>El comentari és massa llarg ({ limit } caràcters com a màxim)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.cs.xlf
+++ b/translations/validators+intl-icu.cs.xlf
@@ -8,7 +8,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Příspěvek je příliš krátký (musí mít minimálně {{ limit }} znak)|Příspěvek je příliš krátký (musí mít minimálně {{ limit }} znaky)|Příspěvek je příliš krátký (musí mít minimálně {{ limit }} znaků)</target>
+                <target>Příspěvek je příliš krátký (musí mít minimálně { limit } znak)|Příspěvek je příliš krátký (musí mít minimálně { limit } znaky)|Příspěvek je příliš krátký (musí mít minimálně { limit } znaků)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -16,11 +16,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Komentář je příliš krátký (musí mít minimálně {{ limit }} znak)|Komentář je příliš krátký (musí mít minimálně {{ limit }} znaky)|Komentář je příliš krátký (musí mít minimálně {{ limit }} znaků)</target>
+                <target>Komentář je příliš krátký (musí mít minimálně { limit } znak)|Komentář je příliš krátký (musí mít minimálně { limit } znaky)|Komentář je příliš krátký (musí mít minimálně { limit } znaků)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Komentář je příliš dlouhý (musí mít maximálně {{ limit }} znak)|Komentář je příliš dlouhý (musí mít maximálně {{ limit }} znaky)|Komentář je příliš dlouhý (musí mít maximálně {{ limit }} znaků)</target>
+                <target>Komentář je příliš dlouhý (musí mít maximálně { limit } znak)|Komentář je příliš dlouhý (musí mít maximálně { limit } znaky)|Komentář je příliš dlouhý (musí mít maximálně { limit } znaků)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.de.xlf
+++ b/translations/validators+intl-icu.de.xlf
@@ -12,7 +12,7 @@
         </trans-unit>
         <trans-unit id="post.too_short_content">
             <source>post.too_short_content</source>
-            <target>Der Beitragsinhalt ist zu kurz (mindestens {{ limit }} Zeichen)</target>
+            <target>Der Beitragsinhalt ist zu kurz (mindestens { limit } Zeichen)</target>
         </trans-unit>
         <trans-unit id="comment.blank">
             <source>comment.blank</source>
@@ -20,11 +20,11 @@
         </trans-unit>
         <trans-unit id="comment.too_short">
             <source>comment.too_short</source>
-            <target>Der Kommentar ist zu kurz (mindestens {{ limit }} Zeichen)</target>
+            <target>Der Kommentar ist zu kurz (mindestens { limit } Zeichen)</target>
         </trans-unit>
         <trans-unit id="comment.too_long">
             <source>comment.too_long</source>
-            <target>Der Kommentar ist zu lang (maximal {{ limit }} Zeichen)</target>
+            <target>Der Kommentar ist zu lang (maximal { limit } Zeichen)</target>
         </trans-unit>
         <trans-unit id="comment.is_spam">
             <source>comment.is_spam</source>
@@ -32,7 +32,7 @@
         </trans-unit>
         <trans-unit id="post.too_many_tags">
             <source>post.too_many_tags</source>
-            <target>Zu viele Tags (höchstens {{ limit }} Tags sind erlaubt)</target>
+            <target>Zu viele Tags (höchstens { limit } Tags sind erlaubt)</target>
         </trans-unit>
         </body>
     </file>

--- a/translations/validators+intl-icu.en.xlf
+++ b/translations/validators+intl-icu.en.xlf
@@ -12,11 +12,11 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Post content is too short ({{ limit }} characters minimum)</target>
+                <target>Post content is too short ({ limit } characters minimum)</target>
             </trans-unit>
             <trans-unit id="post.too_many_tags">
                 <source>post.too_many_tags</source>
-                <target>Too many tags (add {{ limit }} tags or less)</target>
+                <target>Too many tags (add { limit } tags or less)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Comment is too short ({{ limit }} characters minimum)</target>
+                <target>Comment is too short ({ limit } characters minimum)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Comment is too long ({{ limit }} characters maximum)</target>
+                <target>Comment is too long ({ limit } characters maximum)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.es.xlf
+++ b/translations/validators+intl-icu.es.xlf
@@ -12,11 +12,11 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>El contenido del artículo es demasiado corto ({{ limit }} caracteres como mínimo)</target>
+                <target>El contenido del artículo es demasiado corto ({ limit } caracteres como mínimo)</target>
             </trans-unit>
             <trans-unit id="post.too_many_tags">
                 <source>post.too_many_tags</source>
-                <target>Demasiadas etiquetas (añade {{ limit }} como máximo)</target>
+                <target>Demasiadas etiquetas (añade { limit } como máximo)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>El comentario es demasiado corto ({{ limit }} caracteres como mínimo)</target>
+                <target>El comentario es demasiado corto ({ limit } caracteres como mínimo)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>El comentario es demasiado largo ({{ limit }} caracteres como máximo)</target>
+                <target>El comentario es demasiado largo ({ limit } caracteres como máximo)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.fr.xlf
+++ b/translations/validators+intl-icu.fr.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Le contenu de votre post est trop court ({{ limit }} caractères minimum)</target>
+                <target>Le contenu de votre post est trop court ({ limit } caractères minimum)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Votre commentaire est trop court ({{ limit }} caractères minimum)</target>
+                <target>Votre commentaire est trop court ({ limit } caractères minimum)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Votre commentaire est trop long ({{ limit }} caractères maximum)</target>
+                <target>Votre commentaire est trop long ({ limit } caractères maximum)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.hr.xlf
+++ b/translations/validators+intl-icu.hr.xlf
@@ -12,11 +12,11 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Sadržaj članka je prekratak (koristiti minimalno {{ limit }} slova ili simbola)</target>
+                <target>Sadržaj članka je prekratak (koristiti minimalno { limit } slova ili simbola)</target>
             </trans-unit>
             <trans-unit id="post.too_many_tags">
                 <source>post.too_many_tags</source>
-                <target>Previše oznaka (dodaj najviše {{ limit }} oznaka ili manje)</target>
+                <target>Previše oznaka (dodaj najviše { limit } oznaka ili manje)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Komentar je prekratak (potrebno je minimalno {{ limit }} slova ili simbola)</target>
+                <target>Komentar je prekratak (potrebno je minimalno { limit } slova ili simbola)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Komentar je predugačak (koristiti maksimalno {{ limit }} slova ili simbola)</target>
+                <target>Komentar je predugačak (koristiti maksimalno { limit } slova ili simbola)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.id.xlf
+++ b/translations/validators+intl-icu.id.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Konten terlalu singkat (Minimal {{ limit }} karakter)</target>
+                <target>Konten terlalu singkat (Minimal { limit } karakter)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Komentar terlalu singkat (Minimal {{ limit }} karakter)</target>
+                <target>Komentar terlalu singkat (Minimal { limit } karakter)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Komentar terlalu panjang (Maksimal {{ limit }} karakter)</target>
+                <target>Komentar terlalu panjang (Maksimal { limit } karakter)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.it.xlf
+++ b/translations/validators+intl-icu.it.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Il contenuto del post è troppo breve (minimo {{ limit }} caratteri)</target>
+                <target>Il contenuto del post è troppo breve (minimo { limit } caratteri)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Il commento è troppo breve (minimo {{ limit }} caratteri)</target>
+                <target>Il commento è troppo breve (minimo { limit } caratteri)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Il commento è troppo lungo (massimo {{ limit }} caratteri)</target>
+                <target>Il commento è troppo lungo (massimo { limit } caratteri)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.ja.xlf
+++ b/translations/validators+intl-icu.ja.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>本文が短すぎます ({{ limit }} 文字以上必要です)</target>
+                <target>本文が短すぎます ({ limit } 文字以上必要です)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>コメントが短すぎます ({{ limit }} 文字以上必要です)</target>
+                <target>コメントが短すぎます ({ limit } 文字以上必要です)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>コメントが長すぎます ({{ limit }} 文字以下にしてください)</target>
+                <target>コメントが長すぎます ({ limit } 文字以下にしてください)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.nl.xlf
+++ b/translations/validators+intl-icu.nl.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Bericht inhoud is te kort (minimaal {{ limit }} karakters)</target>
+                <target>Bericht inhoud is te kort (minimaal { limit } karakters)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Reactie is te kort (minimaal {{ limit }} karakters)</target>
+                <target>Reactie is te kort (minimaal { limit } karakters)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Reactie is te lang (maximaal {{ limit }} karakters)</target>
+                <target>Reactie is te lang (maximaal { limit } karakters)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.pl.xlf
+++ b/translations/validators+intl-icu.pl.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Treść artykułu jest za krótka (minimum: {{ limit }} znak)|Treść artykułu jest za krótka (minimum: {{ limit }} znaki)|Treść artykułu jest za krótka (minimum: {{ limit }} znaków)</target>
+                <target>Treść artykułu jest za krótka (minimum: { limit } znak)|Treść artykułu jest za krótka (minimum: { limit } znaki)|Treść artykułu jest za krótka (minimum: { limit } znaków)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Twój komentarz jest za krótki (minimum: {{ limit }} znak)|Twój komentarz jest za krótki (minimum: {{ limit }} znaki)|Twój komentarz jest za krótki (minimum: {{ limit }} znaków)</target>
+                <target>Twój komentarz jest za krótki (minimum: { limit } znak)|Twój komentarz jest za krótki (minimum: { limit } znaki)|Twój komentarz jest za krótki (minimum: { limit } znaków)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Twój komentarz jest za długi (maksimum: {{ limit }} znak)|Twój komentarz jest za długi (maksimum: {{ limit }} znaki)|Twój komentarz jest za długi (maksimum: {{ limit }} znaków)</target>
+                <target>Twój komentarz jest za długi (maksimum: { limit } znak)|Twój komentarz jest za długi (maksimum: { limit } znaki)|Twój komentarz jest za długi (maksimum: { limit } znaków)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.pt_BR.xlf
+++ b/translations/validators+intl-icu.pt_BR.xlf
@@ -12,11 +12,11 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>O conteúdo do post está muito curto (mínimo de {{ limit }} caracteres)</target>
+                <target>O conteúdo do post está muito curto (mínimo de { limit } caracteres)</target>
             </trans-unit>
             <trans-unit id="post.too_many_tags">
                 <source>post.too_many_tags</source>
-                <target>Tags demais (adicione {{ limit }} tags ou menos)</target>
+                <target>Tags demais (adicione { limit } tags ou menos)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>O comentário está muito curto (mínimo de {{ limit }} caracteres)</target>
+                <target>O comentário está muito curto (mínimo de { limit } caracteres)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>O comentário está muito grande (máximo de {{ limit }} caracteres)</target>
+                <target>O comentário está muito grande (máximo de { limit } caracteres)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.ro.xlf
+++ b/translations/validators+intl-icu.ro.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Conţinutul articolului este prea scurt (minimum {{ limit }} caractere)</target>
+                <target>Conţinutul articolului este prea scurt (minimum { limit } caractere)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Comentariul este prea scurt (minimum {{ limit }} caractere)</target>
+                <target>Comentariul este prea scurt (minimum { limit } caractere)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Comentariul este prea lung (maximum {{ limit }} caractere)</target>
+                <target>Comentariul este prea lung (maximum { limit } caractere)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.ru.xlf
+++ b/translations/validators+intl-icu.ru.xlf
@@ -12,11 +12,11 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Содержание записи слишком короткое (минимум {{ limit }} символов).</target>
+                <target>Содержание записи слишком короткое (минимум { limit } символов).</target>
             </trans-unit>
             <trans-unit id="post.too_many_tags">
                 <source>post.too_many_tags</source>
-                <target>Слишком много тегов (добавьте {{ limit }} тегов или меньше)</target>
+                <target>Слишком много тегов (добавьте { limit } тегов или меньше)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Комментарий слишком короткий, (минимум {{ limit }} символов).</target>
+                <target>Комментарий слишком короткий, (минимум { limit } символов).</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Комментарий слишком длинный, (максимум {{ limit }} символов).</target>
+                <target>Комментарий слишком длинный, (максимум { limit } символов).</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.sl.xlf
+++ b/translations/validators+intl-icu.sl.xlf
@@ -12,11 +12,11 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Vsebina objave je prekratka (vsaj {{ limit }} znakov)</target>
+                <target>Vsebina objave je prekratka (vsaj { limit } znakov)</target>
             </trans-unit>
             <trans-unit id="post.too_many_tags">
                 <source>post.too_many_tags</source>
-                <target>Preveč značk (dodajte {{ limit }} ali manj značk)</target>
+                <target>Preveč značk (dodajte { limit } ali manj značk)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Komentar je prekratek (vsaj {{ limit }} znakov)</target>
+                <target>Komentar je prekratek (vsaj { limit } znakov)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Komentar je predolg (največ {{ limit }} znakov)</target>
+                <target>Komentar je predolg (največ { limit } znakov)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.tr.xlf
+++ b/translations/validators+intl-icu.tr.xlf
@@ -12,11 +12,11 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Yayın içeriği çok kısa ({{ limit }} minimum karakter)</target>
+                <target>Yayın içeriği çok kısa ({ limit } minimum karakter)</target>
             </trans-unit>
             <trans-unit id="post.too_many_tags">
                 <source>post.too_many_tags</source>
-                <target>Çok fazla etiket var ({{ limit }} etiketini veya daha azını ekleyin)</target>
+                <target>Çok fazla etiket var ({ limit } etiketini veya daha azını ekleyin)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Yorum çok kısa ({{ limit }} minimum karakter)</target>
+                <target>Yorum çok kısa ({ limit } minimum karakter)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Yorum çok uzun ({{ limit }} maksimum karakter)</target>
+                <target>Yorum çok uzun ({ limit } maksimum karakter)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.uk.xlf
+++ b/translations/validators+intl-icu.uk.xlf
@@ -12,11 +12,11 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Зміст запису занадто короткий (мінімум {{ limit }} символів).</target>
+                <target>Зміст запису занадто короткий (мінімум { limit } символів).</target>
             </trans-unit>
             <trans-unit id="post.too_many_tags">
                 <source>post.too_many_tags</source>
-                <target>Занадто багато тегів (додайте {{ limit }} тегів або менше)</target>
+                <target>Занадто багато тегів (додайте { limit } тегів або менше)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Коментар занадто короткий, (мінімум {{ limit }} символів).</target>
+                <target>Коментар занадто короткий, (мінімум { limit } символів).</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Коментар занадто довгий, (максимум {{ limit }} символів).</target>
+                <target>Коментар занадто довгий, (максимум { limit } символів).</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>

--- a/translations/validators+intl-icu.zh_CN.xlf
+++ b/translations/validators+intl-icu.zh_CN.xlf
@@ -12,11 +12,11 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>文章内容太少 最少 ({{ limit }} 个字 )</target>
+                <target>文章内容太少 最少 ({ limit } 个字 )</target>
             </trans-unit>
             <trans-unit id="post.too_many_tags">
                 <source>post.too_many_tags</source>
-                <target>标签太多 (最多 {{ limit }} 个标签)</target>
+                <target>标签太多 (最多 { limit } 个标签)</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>评论内容太少 (最少 {{ limit }} 个字)</target>
+                <target>评论内容太少 (最少 { limit } 个字)</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>评论内容太多 (最多 {{ limit }} 个字)</target>
+                <target>评论内容太多 (最多 { limit } 个字)</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>


### PR DESCRIPTION
I've run a simple Symfony demo and if you try to edit a post with 5 tags, you get an error due to [MessageFormatter](http://php.net/manual/fr/class.messageformatter.php) from icu used in [IntlFormatter](https://github.com/symfony/translation/blob/master/Formatter/IntlFormatter.php). It's due to ```{{ limit }}``` in message.

No documentation about that but we can see in a [test](https://github.com/symfony/translation/blob/master/Tests/Formatter/IntlFormatterTest.php#L88) that ```{ variable }``` can be processed. So we must use ```{ limit }``` and no ```{{ limit }}``` in message translate with icu.

I think to submit a PR to translation component for we can use ```{{ limit }}``` or ```{ limit }``` syntax.