### PR TITLE
Migrate from HTMLPurifier to html-sanitizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "doctrine/doctrine-migrations-bundle": "^1.3",
         "doctrine/orm": "^2.5.11",
         "erusev/parsedown": "^1.6",
-        "ezyang/htmlpurifier": "^4.9",
         "sensio/framework-extra-bundle": "^5.1",
         "sensiolabs/security-checker": "^5.0",
         "symfony/asset": "*",
@@ -29,6 +28,7 @@
         "symfony/validator": "*",
         "symfony/webpack-encore-bundle": "^1.1",
         "symfony/yaml": "*",
+        "tgalopin/html-sanitizer-bundle": "^1.1",
         "twig/extensions": "^1.5",
         "twig/twig": "^2.6",
         "white-october/pagerfanta-bundle": "^1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1648856e17dd7d4fc09a2512d400674f",
+    "content-hash": "22bc2f6cfea72f3ce22f44e8731c48d2",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1338,53 +1338,6 @@
             "time": "2018-03-08T01:11:30+00:00"
         },
         {
-            "name": "ezyang/htmlpurifier",
-            "version": "v4.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "d85d39da4576a6934b72480be6978fb10c860021"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/d85d39da4576a6934b72480be6978fb10c860021",
-                "reference": "d85d39da4576a6934b72480be6978fb10c860021",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "simpletest/simpletest": "^1.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "HTMLPurifier": "library/"
-                },
-                "files": [
-                    "library/HTMLPurifier.composer.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL"
-            ],
-            "authors": [
-                {
-                    "name": "Edward Z. Yang",
-                    "email": "admin@htmlpurifier.org",
-                    "homepage": "http://ezyang.com"
-                }
-            ],
-            "description": "Standards compliant HTML filter written in PHP",
-            "homepage": "http://htmlpurifier.org/",
-            "keywords": [
-                "html"
-            ],
-            "time": "2018-02-23T01:58:20+00:00"
-        },
-        {
             "name": "jdorn/sql-formatter",
             "version": "v1.2.17",
             "source": {
@@ -1433,6 +1386,138 @@
                 "sql"
             ],
             "time": "2014-01-12T16:20:24+00:00"
+        },
+        {
+            "name": "league/uri-parser",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-parser.git",
+                "reference": "671548427e4c932352d9b9279fdfa345bf63fa00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-parser/zipball/671548427e4c932352d9b9279fdfa345bf63fa00",
+                "reference": "671548427e4c932352d9b9279fdfa345bf63fa00",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "phpstan/phpstan": "^0.9.2",
+                "phpstan/phpstan-phpunit": "^0.9.4",
+                "phpstan/phpstan-strict-rules": "^0.9.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-intl": "Allow parsing RFC3987 compliant hosts",
+                "league/uri-schemes": "Allow validating and normalizing URI parsing results"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "userland URI parser RFC 3986 compliant",
+            "homepage": "https://github.com/thephpleague/uri-parser",
+            "keywords": [
+                "parse_url",
+                "parser",
+                "rfc3986",
+                "rfc3987",
+                "uri",
+                "url"
+            ],
+            "time": "2018-11-22T07:55:51+00:00"
+        },
+        {
+            "name": "masterminds/html5",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "b5d892a4bd058d61f736935d32a9c248f11ccc93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/b5d892a4bd058d61f736935d32a9c248f11ccc93",
+                "reference": "b5d892a4bd058d61f736935d32a9c248f11ccc93",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35",
+                "sami/sami": "~2.0",
+                "satooshi/php-coveralls": "1.0.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "time": "2018-12-27T22:03:43+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -4811,6 +4896,94 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2019-01-16T20:35:37+00:00"
+        },
+        {
+            "name": "tgalopin/html-sanitizer",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tgalopin/html-sanitizer.git",
+                "reference": "286e4f3d13cf0294d968a6022647e5d6bc708b60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tgalopin/html-sanitizer/zipball/286e4f3d13cf0294d968a6022647e5d6bc708b60",
+                "reference": "286e4f3d13cf0294d968a6022647e5d6bc708b60",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "league/uri-parser": "^1.4.1",
+                "masterminds/html5": "^2.4",
+                "php": ">=7.1",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.4",
+                "symfony/var-dumper": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "HtmlSanitizer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com"
+                }
+            ],
+            "description": "Sanitize untrustworthy HTML user input",
+            "time": "2018-12-01T15:16:40+00:00"
+        },
+        {
+            "name": "tgalopin/html-sanitizer-bundle",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tgalopin/html-sanitizer-bundle.git",
+                "reference": "fe9c3d1000717031980f9243fd514f70f9923f6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tgalopin/html-sanitizer-bundle/zipball/fe9c3d1000717031980f9243fd514f70f9923f6f",
+                "reference": "fe9c3d1000717031980f9243fd514f70f9923f6f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "symfony/framework-bundle": "^3.4|^4.0",
+                "tgalopin/html-sanitizer": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.4",
+                "symfony/form": "^4.1",
+                "symfony/twig-bundle": "^4.1",
+                "symfony/var-dumper": "^4.1"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "HtmlSanitizer\\Bundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com"
+                }
+            ],
+            "description": "Symfony Bundle for https://github.com/tgalopin/html-sanitizer",
+            "time": "2018-11-28T18:16:56+00:00"
         },
         {
             "name": "twig/extensions",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -17,4 +17,5 @@ return [
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
+    HtmlSanitizer\Bundle\HtmlSanitizerBundle::class => ['all' => true],
 ];

--- a/config/packages/html_sanitizer.yaml
+++ b/config/packages/html_sanitizer.yaml
@@ -1,0 +1,15 @@
+html_sanitizer:
+    default_sanitizer: 'default'
+    sanitizers:
+        default:
+            # Read https://github.com/tgalopin/html-sanitizer/blob/master/docs/1-getting-started.md#extensions
+            # to learn more about which extensions you would like to enable.
+            extensions:
+                - 'basic'
+                - 'list'
+                - 'table'
+                - 'image'
+                - 'code'
+
+            # Read https://github.com/tgalopin/html-sanitizer/blob/master/docs/3-configuration-reference.md
+            # to discover all the available options for each extension.

--- a/src/Utils/Markdown.php
+++ b/src/Utils/Markdown.php
@@ -11,6 +11,8 @@
 
 namespace App\Utils;
 
+use HtmlSanitizer\SanitizerInterface;
+
 /**
  * This class is a light interface between an external Markdown parser library
  * and the application. It's generally recommended to create these light interfaces
@@ -22,22 +24,18 @@ namespace App\Utils;
 class Markdown
 {
     private $parser;
-    private $purifier;
+    private $sanitizer;
 
-    public function __construct()
+    public function __construct(SanitizerInterface $sanitizer)
     {
         $this->parser = new \Parsedown();
-
-        $purifierConfig = \HTMLPurifier_Config::create([
-            'Cache.DefinitionImpl' => null, // Disable caching
-        ]);
-        $this->purifier = new \HTMLPurifier($purifierConfig);
+        $this->sanitizer = $sanitizer;
     }
 
     public function toHtml(string $text): string
     {
         $html = $this->parser->text($text);
-        $safeHtml = $this->purifier->purify($html);
+        $safeHtml = $this->sanitizer->sanitize($html);
 
         return $safeHtml;
     }

--- a/symfony.lock
+++ b/symfony.lock
@@ -101,9 +101,6 @@
     "erusev/parsedown": {
         "version": "1.8.0-beta-5"
     },
-    "ezyang/htmlpurifier": {
-        "version": "v4.10.0"
-    },
     "friendsofphp/php-cs-fixer": {
         "version": "2.2",
         "recipe": {
@@ -115,6 +112,12 @@
     },
     "jdorn/sql-formatter": {
         "version": "1.3.x-dev"
+    },
+    "league/uri-parser": {
+        "version": "1.4.1"
+    },
+    "masterminds/html5": {
+        "version": "2.5.0"
     },
     "monolog/monolog": {
         "version": "1.x-dev"
@@ -412,6 +415,18 @@
     },
     "symfony/yaml": {
         "version": "4.2-dev"
+    },
+    "tgalopin/html-sanitizer": {
+        "version": "1.1.1"
+    },
+    "tgalopin/html-sanitizer-bundle": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "26a72f38eede2c53b5d3ccbed5c150e10a93268d"
+        }
     },
     "twig/extensions": {
         "version": "1.0",


### PR DESCRIPTION
I would like to propose the usage of html-sanitizer in remplacement of HTMLPurifier.

html-sanitizer is well integrated in modern Symfony applications (autowiring / autoconfiguration), it is better suited than HTMLPurifier to sanitize user inputs such as Markdown, it is faster and it creates HTML that's simpler and easier to understand. It is also IMO easier to extends and configure.