### PR TITLE
Update dependencies to Twig 2.7.3 to avoid security check red warning

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5045,16 +5045,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.6.2",
+            "version": "v2.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "7d7342c8a4059fefb9b8d07db0cc14007021f9b7"
+                "reference": "52b9a5bd41c8c53a1d784f90ca25e33bf558a6b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/7d7342c8a4059fefb9b8d07db0cc14007021f9b7",
-                "reference": "7d7342c8a4059fefb9b8d07db0cc14007021f9b7",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/52b9a5bd41c8c53a1d784f90ca25e33bf558a6b3",
+                "reference": "52b9a5bd41c8c53a1d784f90ca25e33bf558a6b3",
                 "shasum": ""
             },
             "require": {
@@ -5070,7 +5070,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
@@ -5108,7 +5108,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2019-01-14T15:00:48+00:00"
+            "time": "2019-03-21T14:53:02+00:00"
         },
         {
             "name": "white-october/pagerfanta-bundle",


### PR DESCRIPTION
If you install Symfony Demo now, you'll get the security check warning:
```
Executing script security-checker security:check [KO]
 [KO]
Script security-checker security:check returned with error code 1
!!  Symfony Security Check Report
!!  =============================
!!
!!  1 packages have known vulnerabilities.
!!
!!  twig/twig (v2.6.2)
!!  ------------------
!!
!!   * [CVE-NONE-0001][]: Sandbox Information Disclosure
!!
!!  [CVE-NONE-0001]: https://symfony.com/blog/twig-sandbox-information-disclosure
!!
!!  Note that this checker can only detect vulnerabilities that are referenced in the SensioLabs security advisories database.
!!  Execute this command regularly to check the newly discovered vulnerabilities.
!!
Script @auto-scripts was called via post-install-cmd
```

Consequently twig needs to be updated to v2.7.3 in order to remove this warning (and avoid scaring people away 😄)