### PR TITLE
Remove beta minimum stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,5 @@
             "allow-contrib": true,
             "require": "4.3.*"
         }
-    },
-    "minimum-stability": "beta"
+    }
 }


### PR DESCRIPTION
Merging https://github.com/symfony/demo/commit/e26780b8d740f9074383a4983fa4d8e4904b0878#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R92 brought back minimum stability to beta.

Since Symfony 4.3 is stable, I think it's safe to remove it.