### PR TITLE
Do not install assets with "--symlink --relative"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
     "scripts": {
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
-            "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd",
             "security-checker security:check": "script"
         },
         "post-install-cmd": [


### PR DESCRIPTION
By default do not install assets with "--symlink --relative".