### PR TITLE
Fail CI if the repo is in a dirty state after building assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 sudo: false
 
 cache:
+  yarn: true
   directories:
     - $HOME/.composer/cache/files
     - ./bin/.phpunit
@@ -43,3 +44,5 @@ script:
   - ./bin/console security:check
   # this checks that Doctrine's mapping configurations are valid
   - ./bin/console doctrine:schema:validate --skip-sync -vvv --no-interaction
+  #  Fail CI if the repo is in a dirty state after building assets
+  - yarn install && yarn build && git add --all && git diff --staged --shortstat --exit-code


### PR DESCRIPTION
In order to prevent things fixed in #982 I think we can check for missing assets on TravisCI

Tests should pass after merging #982