### PR TITLE
chore(phpunit): remove lines for `SYMFONY_PHPUNIT_REMOVE`

### DIFF
--- a/bin/phpunit
+++ b/bin/phpunit
@@ -5,9 +5,7 @@ if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-php
     echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
     exit(1);
 }
-if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
-    putenv('SYMFONY_PHPUNIT_REMOVE=');
-}
+
 if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
     putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');
 }


### PR DESCRIPTION
It's a following of #1000.

The `phpunit` binary looks [like this](https://github.com/symfony/recipes/blob/master/symfony/phpunit-bridge/4.3/bin/phpunit) for Symfony 4.3, we don't need `SYMFONY_PHPUNIT_REMOVE` lines too.

I also think we don't need `SYMFONY_PHPUNIT_DIR` lines but I'm not really sure (it's working fine without those lines in one of our app).