### PR TITLE
Added a Paginator object based on Doctrine's paginator

### DIFF
--- a/src/Pagination/Paginator.php
+++ b/src/Pagination/Paginator.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Pagination;
+
+use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
+use Doctrine\ORM\Tools\Pagination\CountWalker;
+use Doctrine\ORM\Tools\Pagination\Paginator as DoctrinePaginator;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class Paginator
+{
+    private const PAGE_SIZE = 10;
+    private $queryBuilder;
+    private $currentPage;
+    private $pageSize;
+    private $results;
+    private $numResults;
+
+    public function __construct(DoctrineQueryBuilder $queryBuilder, int $pageSize = self::PAGE_SIZE)
+    {
+        $this->queryBuilder = $queryBuilder;
+        $this->pageSize = $pageSize;
+    }
+
+    public function paginate(int $page = 1): self
+    {
+        $this->currentPage = max(1, $page);
+        $firstResult = ($this->currentPage - 1) * $this->pageSize;
+
+        $query = $this->queryBuilder
+            ->setFirstResult($firstResult)
+            ->setMaxResults($this->pageSize)
+            ->getQuery();
+
+        if (0 === \count($this->queryBuilder->getDQLPart('join'))) {
+            $query->setHint(CountWalker::HINT_DISTINCT, false);
+        }
+
+        $paginator = new DoctrinePaginator($query, true);
+
+        $useOutputWalkers = \count($this->queryBuilder->getDQLPart('having') ?: []) > 0;
+        $paginator->setUseOutputWalkers($useOutputWalkers);
+
+        $this->results = $paginator->getIterator();
+        $this->numResults = $paginator->count();
+
+        return $this;
+    }
+
+    public function getCurrentPage(): int
+    {
+        return $this->currentPage;
+    }
+
+    public function getLastPage(): int
+    {
+        return (int) ceil($this->numResults / $this->pageSize);
+    }
+
+    public function getPageSize(): int
+    {
+        return $this->pageSize;
+    }
+
+    public function hasPreviousPage(): bool
+    {
+        return $this->currentPage > 1;
+    }
+
+    public function getPreviousPage(): int
+    {
+        return max(1, $this->currentPage - 1);
+    }
+
+    public function hasNextPage(): bool
+    {
+        return $this->currentPage < $this->getLastPage();
+    }
+
+    public function getNextPage(): int
+    {
+        return min($this->getLastPage(), $this->currentPage + 1);
+    }
+
+    public function hasToPaginate(): bool
+    {
+        return $this->numResults > $this->pageSize;
+    }
+
+    public function getNumResults(): int
+    {
+        return $this->numResults;
+    }
+
+    public function getResults(): \Traversable
+    {
+        return $this->results;
+    }
+}

--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -24,7 +24,7 @@
         <div class="well">{{ 'post.no_posts_found'|trans }}</div>
     {% endfor %}
 
-    {% if paginator.haveToPaginate %}
+    {% if paginator.hasToPaginate %}
         <div class="navigation text-center">
             <ul class="pagination">
                 {% if paginator.hasPreviousPage %}
@@ -33,7 +33,7 @@
                     <li class="prev disabled"><span><i class="fa fw fa-arrow-left"></i> Previous</span></li>
                 {% endif %}
 
-                {% for i in 1..paginator.numPages %}
+                {% for i in 1..paginator.lastPage %}
                     {% if i == paginator.currentPage %}
                         <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
                     {% else %}


### PR DESCRIPTION
The current code uses an array to provide the pagination information. We did that as part of the quick proof-of-concept replacement of Pagerfanta library.

This PR proposes to replace that array by a proper object. The new design was based on the one proposed by EasyAdmin to also replace Pagerfanta (https://github.com/EasyCorp/EasyAdminBundle/pull/2777).