### PR TITLE
Prevent blog_index from breaking because of forbidden characters in the slug

### DIFF
--- a/src/Utils/Slugger.php
+++ b/src/Utils/Slugger.php
@@ -14,6 +14,7 @@ namespace App\Utils;
 /**
  * @author Ryan Weaver <weaverryan@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ * @author Douglas Silva <doug.hs@protonmail.ch>
  */
 class Slugger
 {

--- a/src/Utils/Slugger.php
+++ b/src/Utils/Slugger.php
@@ -15,14 +15,14 @@ namespace App\Utils;
  * @author Ryan Weaver <weaverryan@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Douglas Silva <doug.hs@protonmail.ch>
+ * @author Josef Kufner <???>
  */
 class Slugger
 {
     public static function slugify(string $string): string
     {
-        $slug = preg_replace('/\s+/', '-', mb_strtolower(trim($string), 'UTF-8'));
-        $slug = preg_replace('/[^a-z0-9-]/', '', $slug);
+        $slug = preg_replace('/[^a-z0-9-]+/', '-', mb_strtolower($string, 'UTF-8'));
 
-        return $slug;
+        return trim($slug, '-');
     }
 }

--- a/src/Utils/Slugger.php
+++ b/src/Utils/Slugger.php
@@ -19,6 +19,9 @@ class Slugger
 {
     public static function slugify(string $string): string
     {
-        return preg_replace('/\s+/', '-', mb_strtolower(trim(strip_tags($string)), 'UTF-8'));
+        $slug = preg_replace('/\s+/', '-', mb_strtolower(trim($string), 'UTF-8'));
+        $slug = preg_replace('/[^a-z0-9-]/', '', $slug);
+
+        return $slug;
     }
 }


### PR DESCRIPTION
This was explained on the issue [1018](https://github.com/symfony/demo/issues/1018).

If someone writes a title `/test`, the resulting slug will be `/test`, which will trigger an error:
```
An exception has been thrown during the rendering of a template ("Parameter "slug" for route "blog_post" must match "[^/]++" ("/test" given) to generate a corresponding URL.").
```
Nothing is currently removing forward slashes for the slug. That is not the case for backward slashes `\`, though.

Now if someone writes a title named `<this is a test`, the resulting slug will be empty, and the same exception will be raised when you access blog_index.

This happens because `strip_tags()` is removing everything after the opening tag. The page on the PHP Manual about this function warns about that.

This solution removes `strip_tags()` from the Slugger and uses a regex to catch forbidden characters. The resulting slugs look good thanks to @jkufner. A title `hello :) world-` will result in the slug `hello-world`, for example.