### PR TITLE
Make paginator strings translatable

### DIFF
--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -28,23 +28,23 @@
         <div class="navigation text-center">
             <ul class="pagination">
                 {% if paginator.hasPreviousPage %}
-                    <li class="prev"><a href="{{ path('blog_index_paginated', {page: paginator.previousPage}) }}" rel="previous"><i class="fa fw fa-long-arrow-left"></i> Previous</a></li>
+                    <li class="prev"><a href="{{ path('blog_index_paginated', {page: paginator.previousPage}) }}" rel="previous"><i class="fa fw fa-long-arrow-left"></i> {{ 'paginator.previous'|trans }}</a></li>
                 {% else %}
-                    <li class="prev disabled"><span><i class="fa fw fa-arrow-left"></i> Previous</span></li>
+                    <li class="prev disabled"><span><i class="fa fw fa-arrow-left"></i> {{ 'paginator.previous'|trans }}</span></li>
                 {% endif %}
 
                 {% for i in 1..paginator.lastPage %}
                     {% if i == paginator.currentPage %}
-                        <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+                        <li class="active"><span>{{ i }} <span class="sr-only">{{ 'paginator.current'|trans }}</span></span></li>
                     {% else %}
                         <li><a href="{{ path('blog_index_paginated', {page: i}) }}">{{ i }}</a></li>
                     {% endif %}
                 {% endfor %}
 
                 {% if paginator.hasNextPage %}
-                    <li class="next"><a href="{{ path('blog_index_paginated', {page: paginator.nextPage}) }}" rel="next">Next <i class="fa fw fa-arrow-right"></i></a></li>
+                    <li class="next"><a href="{{ path('blog_index_paginated', {page: paginator.nextPage}) }}" rel="next">{{ 'paginator.next'|trans }} <i class="fa fw fa-arrow-right"></i></a></li>
                 {% else %}
-                    <li class="next disabled"><span>Next <i class="fa fw fa-arrow-right"></i></span></li>
+                    <li class="next disabled"><span>{{ 'paginator.next'|trans }} <i class="fa fw fa-arrow-right"></i></span></li>
                 {% endif %}
             </ul>
         </div>

--- a/translations/messages+intl-icu.bg.xlf
+++ b/translations/messages+intl-icu.bg.xlf
@@ -350,6 +350,15 @@
                 <source>rss.description</source>
                 <target>Най-новите публикации, публикувани на блога на Symfony Demo</target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Предишна</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Следваща</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.cs.xlf
+++ b/translations/messages+intl-icu.cs.xlf
@@ -244,6 +244,15 @@
                 <source>help.more_information</source>
                 <target><![CDATA[Pro více informací přejděte do <a href="https://symfony.com/doc">Symfony dokumentace</a>.]]></target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Předchozí</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Další</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.de.xlf
+++ b/translations/messages+intl-icu.de.xlf
@@ -352,6 +352,15 @@
                 <source>notification.comment_created.description</source>
                 <target><![CDATA[Dein Beitrag "{title}" hat einen Kommentar erhalten. Du kannst den Kommentar lesen, wenn du <a href="{link}">diesem Link</a> folgst.]]></target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Vorherige</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Nächste</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -425,6 +425,19 @@
                 <source>rss.description</source>
                 <target>Most recent posts published on the Symfony Demo blog</target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Previous</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Next</target>
+            </trans-unit>
+            <trans-unit id="paginator.current">
+                <source>paginator.current</source>
+                <target>(current)</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.es.xlf
+++ b/translations/messages+intl-icu.es.xlf
@@ -357,6 +357,15 @@
                 <source>rss.description</source>
                 <target>Publicaciones más recientes publicadas en el blog de Symfony Demo</target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Anterior</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Seguiente</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.fr.xlf
+++ b/translations/messages+intl-icu.fr.xlf
@@ -425,6 +425,15 @@
                 <source>rss.description</source>
                 <target>Derniers articles publiés sur le blog de démo Symfony</target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Précédent</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Suivant</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.id.xlf
+++ b/translations/messages+intl-icu.id.xlf
@@ -236,6 +236,15 @@
                 <source>help.more_information</source>
                 <target><![CDATA[Informasi selengkapnya, kunjungi <a href="https://symfony.com/doc">Symfony doc</a>.]]></target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Sebelumnya</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Berikutnya</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.it.xlf
+++ b/translations/messages+intl-icu.it.xlf
@@ -359,6 +359,15 @@
                 <source>rss.description</source>
                 <target>Post più recenti pubblicati su Symfony Demo blog</target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Precedente</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Successivo</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.ja.xlf
+++ b/translations/messages+intl-icu.ja.xlf
@@ -277,6 +277,15 @@
                 <source>help.more_information</source>
                 <target><![CDATA[さらに詳しく知りたい場合は, <a href="https://symfony.com/doc">Symfony doc</a>を参照してください。]]></target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>前へ</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>次へ</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.lt.xlf
+++ b/translations/messages+intl-icu.lt.xlf
@@ -425,6 +425,15 @@
                 <source>rss.description</source>
                 <target>Naujausi įrašai paskelbti Symfony Demo bloge</target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Ankstesnis</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Sekantis</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.nl.xlf
+++ b/translations/messages+intl-icu.nl.xlf
@@ -359,6 +359,15 @@
                 <source>rss.description</source>
                 <target>De meest recente berichten, gepubliceerd op De Symfony Demo blog</target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Vorige</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Volgende</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.pl.xlf
+++ b/translations/messages+intl-icu.pl.xlf
@@ -275,6 +275,15 @@
                 <source>help.more_information</source>
                 <target><![CDATA[Sprawdź <a href="https://symfony.com/doc">dokumentację Symfony</a>, aby uzyskać więcej informacji.]]></target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Poprzednia</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Następna</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.pt_BR.xlf
+++ b/translations/messages+intl-icu.pt_BR.xlf
@@ -347,6 +347,19 @@
                 <source>rss.description</source>
                 <target>Posts mais recentes publicados no blog Symfony Demo</target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Anterior</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Próxima</target>
+            </trans-unit>
+            <trans-unit id="paginator.current">
+                <source>paginator.current</source>
+                <target>(atual)</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.ro.xlf
+++ b/translations/messages+intl-icu.ro.xlf
@@ -272,6 +272,15 @@
                 <source>help.more_information</source>
                 <target><![CDATA[Pentru mai multe informaţii, citeşte <a href="https://symfony.com/doc">documentaţia Symfony</a>.]]></target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Pagina anterioara</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Pagina urmatoare</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.ru.xlf
+++ b/translations/messages+intl-icu.ru.xlf
@@ -425,6 +425,15 @@
                 <source>rss.description</source>
                 <target>Самые последние записи, опубликованные в Symfony Demo блоге</target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Назад</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Вперед</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages+intl-icu.uk.xlf
+++ b/translations/messages+intl-icu.uk.xlf
@@ -359,6 +359,15 @@
                 <source>rss.description</source>
                 <target>Найновіші записи, опубліковані в Symfony Demo блозі</target>
             </trans-unit>
+
+            <trans-unit id="paginator.previous">
+                <source>paginator.previous</source>
+                <target>Назад</target>
+            </trans-unit>
+            <trans-unit id="paginator.next">
+                <source>paginator.next</source>
+                <target>Далі</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
All but the `pt_BR` translations are based on the translations available on the KnpPaginatorBundle. That bundle doesn't have any string equivalent to "current", so this is why this translation is missing in all languages, except for `pt_BR` and `en`.