### PR TITLE
Update README.md, fix command running php server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ cd my_project/
 $ symfony serve
 ```
 
-If you don't have the Symfony binary installed, run `php -S localhost:8000 -t public/`
+If you don't have the Symfony binary installed, run `php -S localhost:8000 -t public/ public/index.php`
 to use the built-in PHP web server or [configure a web server][3] like Nginx or
 Apache to run the application.
 


### PR DESCRIPTION
According to [this](https://github.com/symfony/recipes/pull/353/files) and [this](symfony/symfony#25911) issues if we start php server with -t key, instead of passing exact file, urls with dots wouldn't been recognized by routing