### PR TITLE
Make tests compatible with PHPUnit 8

### DIFF
--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -26,7 +26,7 @@ class AddUserCommandTest extends KernelTestCase
         'full-name' => 'Chuck Norris',
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         exec('stty 2>&1', $output, $exitcode);
         $isSttySupported = 0 === $exitcode;


### PR DESCRIPTION
`setUp()` method must have a `void` return type declaration. See: https://phpunit.de/announcements/phpunit-8.html