### PR TITLE
Make blog post titles unique

### DIFF
--- a/src/Controller/Admin/BlogController.php
+++ b/src/Controller/Admin/BlogController.php
@@ -21,7 +21,6 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\String\Slugger\SluggerInterface;
 
 /**
  * Controller used to manage blog contents in the backend.
@@ -70,7 +69,7 @@ class BlogController extends AbstractController
      * to constraint the HTTP methods each controller responds to (by default
      * it responds to all methods).
      */
-    public function new(Request $request, SluggerInterface $slugger): Response
+    public function new(Request $request): Response
     {
         $post = new Post();
         $post->setAuthor($this->getUser());
@@ -86,8 +85,6 @@ class BlogController extends AbstractController
         // However, we explicitly add it to improve code readability.
         // See https://symfony.com/doc/current/forms.html#processing-forms
         if ($form->isSubmitted() && $form->isValid()) {
-            $post->setSlug($slugger->slug($post->getTitle())->lower());
-
             $em = $this->getDoctrine()->getManager();
             $em->persist($post);
             $em->flush();
@@ -133,13 +130,12 @@ class BlogController extends AbstractController
      * @Route("/{id<\d+>}/edit",methods={"GET", "POST"}, name="admin_post_edit")
      * @IsGranted("edit", subject="post", message="Posts can only be edited by their authors.")
      */
-    public function edit(Request $request, Post $post, SluggerInterface $slugger): Response
+    public function edit(Request $request, Post $post): Response
     {
         $form = $this->createForm(PostType::class, $post);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $post->setSlug($slugger->slug($post->getTitle())->lower());
             $this->getDoctrine()->getManager()->flush();
 
             $this->addFlash('success', 'post.updated_successfully');

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -14,11 +14,13 @@ namespace App\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity(repositoryClass="App\Repository\PostRepository")
  * @ORM\Table(name="symfony_demo_post")
+ * @UniqueEntity(fields={"slug"}, errorPath="title")
  *
  * Defines the properties of the Post entity to represent the blog posts.
  *

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @ORM\Entity(repositoryClass="App\Repository\PostRepository")
  * @ORM\Table(name="symfony_demo_post")
- * @UniqueEntity(fields={"slug"}, errorPath="title")
+ * @UniqueEntity(fields={"slug"}, errorPath="title", message="This title was already used in another blog post, but they must be unique.")
  *
  * Defines the properties of the Post entity to represent the blog posts.
  *

--- a/src/Form/PostType.php
+++ b/src/Form/PostType.php
@@ -17,7 +17,10 @@ use App\Form\Type\TagsInputType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\String\Slugger\SluggerInterface;
 
 /**
  * Defines the form used to create and manipulate blog posts.
@@ -28,6 +31,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PostType extends AbstractType
 {
+    private $slugger;
+
+    // Form types are services, so you can inject other services in them if needed
+    public function __construct(SluggerInterface $slugger)
+    {
+        $this->slugger = $slugger;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -64,6 +75,16 @@ class PostType extends AbstractType
                 'label' => 'label.tags',
                 'required' => false,
             ])
+            // form events let you modify information or fields at different steps
+            // of the form handling process.
+            // See https://symfony.com/doc/current/form/events.html
+            ->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) {
+                /** @var Post */
+                $post = $event->getData();
+                if (null !== $postTitle = $post->getTitle()) {
+                    $post->setSlug($this->slugger->slug($postTitle)->lower());
+                }
+            })
         ;
     }
 


### PR DESCRIPTION
I'm trying to fix #1045. 

We should make the `slug` unique because it's what we use to look for blog posts in the database. However, I can't make this work. If I define `UniqueEntity` on `title`, it works ... but if I define it on `slug`, it doesn't work (I can create any number of posts with the same slug). Anybody sees the error? Thanks!