### PR TITLE
Validate composer files while TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,3 +57,4 @@ script:
   - ./bin/console doctrine:schema:validate --skip-sync -vvv --no-interaction
   #  Fail CI if the repo is in a dirty state after building assets (only for current release ie install)
   #-  if [[ "$ACTION" == "install" ]]; then yarn install && yarn encore production && git add --all && git diff --staged --exit-code; fi
+  - composer validate


### PR DESCRIPTION
This check prevents us from having an out of sync composer's lock-file (For example, when someone forgot to commit composer.lock file: https://github.com/symfony/demo/pull/1066).