### PR TITLE
Update tgalopin/html-sanitizer

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5446,21 +5446,20 @@
         },
         {
             "name": "tgalopin/html-sanitizer",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tgalopin/html-sanitizer.git",
-                "reference": "8ca76a6ce8c7d66f38a9101769af63bfb5626439"
+                "reference": "56cca6b48de4e50d16a4f549e3e677ae0d561e91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tgalopin/html-sanitizer/zipball/8ca76a6ce8c7d66f38a9101769af63bfb5626439",
-                "reference": "8ca76a6ce8c7d66f38a9101769af63bfb5626439",
+                "url": "https://api.github.com/repos/tgalopin/html-sanitizer/zipball/56cca6b48de4e50d16a4f549e3e677ae0d561e91",
+                "reference": "56cca6b48de4e50d16a4f549e3e677ae0d561e91",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "ext-intl": "*",
                 "league/uri-parser": "^1.4.1",
                 "masterminds/html5": "^2.4",
                 "php": ">=7.1",
@@ -5487,7 +5486,7 @@
                 }
             ],
             "description": "Sanitize untrustworthy HTML user input",
-            "time": "2019-10-24T14:52:22+00:00"
+            "time": "2020-02-03T16:51:08+00:00"
         },
         {
             "name": "tgalopin/html-sanitizer-bundle",


### PR DESCRIPTION
This PR updates the version of tgalopin/html-sanitizer used in order to avoid requiring ext-intl unnecessarily.

```
$ composer up tgalopin/html-sanitizer-bundle tgalopin/html-sanitizer
Loading composer repositories with package information
Updating dependencies (including require-dev)
Restricting packages listed in "symfony/symfony" to "5.0.*"
Package operations: 0 installs, 1 update, 0 removals
  - Updating tgalopin/html-sanitizer (1.3.0 => 1.4.0): Loading from cache
Writing lock file
Generating autoload files
```