### PR TITLE
Remove unnecessary historic configuration: 'sudo: false'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 cache:
   yarn: true


### PR DESCRIPTION
I hope I did enough Googling. I really tried to find a reason to keep `sudo :false` in 2020 but it seems that it has no effect anymore.

I even tried to `sudo echo foo` during Travis' `install` phase and that works with and without `sudo: false`.

Docs: https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments

Blog post stating "If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon": https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

I also created a PR for the Symfony docs: https://github.com/symfony/symfony-docs/pull/13675