### PR TITLE
Add a test for command ListUsers (test emails)

### DIFF
--- a/tests/Command/AbstractCommandTest.php
+++ b/tests/Command/AbstractCommandTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+abstract class AbstractCommandTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        if ('Windows' === \PHP_OS_FAMILY) {
+            $this->markTestSkipped('`stty` is required to test this command.');
+        }
+    }
+
+    /**
+     * This helper method abstracts the boilerplate code needed to test the
+     * execution of a command.
+     *
+     * @param array $arguments All the arguments passed when executing the command
+     * @param array $inputs    The (optional) answers given to the command when it asks for the value of the missing arguments
+     */
+    protected function executeCommand(array $arguments, array $inputs = []): CommandTester
+    {
+        self::bootKernel();
+
+        // this uses a special testing container that allows you to fetch private services
+        $command = self::$container->get($this->getCommandFqcn());
+        $command->setApplication(new Application(self::$kernel));
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs($inputs);
+        $commandTester->execute($arguments);
+
+        return $commandTester;
+    }
+
+    abstract protected function getCommandFqcn(): string;
+}

--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -13,11 +13,8 @@ namespace App\Tests\Command;
 
 use App\Command\AddUserCommand;
 use App\Repository\UserRepository;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\Console\Tester\CommandTester;
 
-class AddUserCommandTest extends KernelTestCase
+class AddUserCommandTest extends AbstractCommandTest
 {
     private $userData = [
         'username' => 'chuck_norris',
@@ -25,13 +22,6 @@ class AddUserCommandTest extends KernelTestCase
         'email' => 'chuck@norris.com',
         'full-name' => 'Chuck Norris',
     ];
-
-    protected function setUp(): void
-    {
-        if ('Windows' === \PHP_OS_FAMILY) {
-            $this->markTestSkipped('Windows OS does not support testing this command.');
-        }
-    }
 
     /**
      * @dataProvider isAdminDataProvider
@@ -97,23 +87,8 @@ class AddUserCommandTest extends KernelTestCase
         $this->assertSame($isAdmin ? ['ROLE_ADMIN'] : ['ROLE_USER'], $user->getRoles());
     }
 
-    /**
-     * This helper method abstracts the boilerplate code needed to test the
-     * execution of a command.
-     *
-     * @param array $arguments All the arguments passed when executing the command
-     * @param array $inputs    The (optional) answers given to the command when it asks for the value of the missing arguments
-     */
-    private function executeCommand(array $arguments, array $inputs = []): void
+    protected function getCommandFqcn(): string
     {
-        self::bootKernel();
-
-        // this uses a special testing container that allows you to fetch private services
-        $command = self::$container->get(AddUserCommand::class);
-        $command->setApplication(new Application(self::$kernel));
-
-        $commandTester = new CommandTester($command);
-        $commandTester->setInputs($inputs);
-        $commandTester->execute($arguments);
+        return AddUserCommand::class;
     }
 }

--- a/tests/Command/ListUsersCommandTest.php
+++ b/tests/Command/ListUsersCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Command;
+
+use App\Command\ListUsersCommand;
+
+class ListUsersCommandTest extends AbstractCommandTest
+{
+    /**
+     * @dataProvider maxResultsProvider
+     *
+     * This test verifies the amount of data is right according to the given parameter max results.
+     */
+    public function testListUsers(int $maxResults): void
+    {
+        $tester = $this->executeCommand(
+            ['--max-results' => $maxResults]
+        );
+
+        $emptyDisplayLines = 5;
+        $this->assertSame($emptyDisplayLines + $maxResults, mb_substr_count($tester->getDisplay(), "\n"));
+    }
+
+    public function maxResultsProvider(): ?\Generator
+    {
+        yield [1];
+        yield [2];
+    }
+
+    public function testItSendsNoEmailByDefault(): void
+    {
+        $this->executeCommand([]);
+
+        $this->assertEmailCount(0);
+    }
+
+    public function testItSendsAnEmailIfOptionProvided(): void
+    {
+        $this->executeCommand(['--send-to' => 'john.doe@symfony.com']);
+
+        $this->assertEmailCount(1);
+    }
+
+    protected function getCommandFqcn(): string
+    {
+        return ListUsersCommand::class;
+    }
+}


### PR DESCRIPTION
The command list user was not tested until now, and that's quite sad because it's one of the only parts of the code that actually sends an email. Symfony has some tools for testing emails, let's use them!

I also refactored a little bit of command testing since there was an identical piece of code between test cases. (instantiating the command)