### PR TITLE
Update _comment_form.html.twig

### DIFF
--- a/templates/blog/_comment_form.html.twig
+++ b/templates/blog/_comment_form.html.twig
@@ -22,7 +22,7 @@
         {{ form_errors(form) }}
 
         <div class="form-group {% if not form.content.vars.valid %}has-error{% endif %}">
-            {{ form_label(form.content, 'label.content', {label_attr: {class: 'hidden'}}) }}
+            {{ form_label(form.content, 'label.content', {label_attr: {class: 'sr-only'}}) }}
 
             {# Render any errors for the "content" field (e.g. when a class property constraint failed) #}
             {{ form_errors(form.content) }}


### PR DESCRIPTION
Hiding the textarea label with CSS makes no sense here. We could simply remove the call `form_label` instead. However I think it makes sense to keep the label for assistive technologies.