### PR TITLE
[5.2] Strict manifest.json on debug

### DIFF
--- a/config/packages/assets.yaml
+++ b/config/packages/assets.yaml
@@ -1,3 +1,4 @@
 framework:
     assets:
         json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'
+        strict: '%kernel.debug%'


### PR DESCRIPTION
Implementing https://github.com/symfony/symfony/pull/38495

Ease development by throwing an exception when an asset is not found in `manifest.json`.
