### PR TITLE
Disable HTTP method override

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -2,7 +2,7 @@
 framework:
     secret: '%env(APP_SECRET)%'
     csrf_protection: true
-    http_method_override: true
+    http_method_override: false
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.


### PR DESCRIPTION
We don't need this since the changes introduced in #427 and this goes in sync with the official Symfony recipe: https://github.com/symfony/recipes/pull/892