### PR TITLE
Update highlight.js

### DIFF
--- a/assets/js/highlight.js
+++ b/assets/js/highlight.js
@@ -1,8 +1,8 @@
-import hljs from 'highlight.js/lib/highlight';
+import hljs from 'highlight.js/lib/core';
 import php from 'highlight.js/lib/languages/php';
 import twig from 'highlight.js/lib/languages/twig';
 
 hljs.registerLanguage('php', php);
 hljs.registerLanguage('twig', twig);
 
-hljs.initHighlightingOnLoad();
+hljs.highlightAll();


### PR DESCRIPTION
Fix the error

app.js:133 Uncaught TypeError: highlight_js_lib_highlight__WEBPACK_IMPORTED_MODULE_0___default.a.registerLanguage is not a function
    at Module../assets/js/highlight.js (app.js:133)
    at __webpack_require__ (runtime.js:80)
    at Module../assets/js/app.js (app.js:26)
    at __webpack_require__ (runtime.js:80)
    at checkDeferredModules (runtime.js:46)
    at Array.webpackJsonpCallback [as push] (runtime.js:33)
    at app.js:1