### PR TITLE
Avoid creating a session when the user is not logged in

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -60,7 +60,7 @@
                                     <a href="{{ path('blog_search') }}"> <i class="fa fa-search"></i> {{ 'menu.search'|trans }}</a>
                                 </li>
 
-                                {% if app.user %}
+                                {% if app.request.hasPreviousSession and app.user %}
                                     <li class="dropdown">
                                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false" id="user">
                                             <i class="fa fa-user" aria-hidden="true"></i>


### PR DESCRIPTION
Calling app.user (app. getUser()) immediately starts a session if a session does not exists. This may create problems for caching public pages.