### PR TITLE
Update workflow triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
     pull_request:
     push:
         branches:
-            - 'master'
+            - main
 
 env:
     fail-fast: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,10 @@
 name: "Lint"
 
-on: [push, pull_request]
+on:
+    pull_request:
+    push:
+        branches:
+            - main
 
 env:
     fail-fast: true


### PR DESCRIPTION
To prevent dependabot from triggering the lint workflow twice