### PR TITLE
Install stty required for tests on ubuntu-latest

### DIFF
--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -28,11 +28,8 @@ class AddUserCommandTest extends KernelTestCase
 
     protected function setUp(): void
     {
-        exec('stty 2>&1', $output, $exitcode);
-        $isSttySupported = 0 === $exitcode;
-
-        if ('Windows' === \PHP_OS_FAMILY || !$isSttySupported) {
-            $this->markTestSkipped('`stty` is required to test this command.');
+        if ('Windows' === \PHP_OS_FAMILY) {
+            $this->markTestSkipped('Windows OS does not support testing this command.');
         }
     }
 


### PR DESCRIPTION
In every test job we have skipped tests:
```
Run vendor/bin/simple-phpunit -v
PHPUnit 9.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.5
Configuration: /home/runner/work/demo/demo/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing 
SSSS...........................................                   47 / 47 (100%)

Time: 00:14.918, Memory: 74.50 MB

There were 4 skipped tests:

1) App\Tests\Command\AddUserCommandTest::testCreateUserNonInteractive with data set #0 (false)
`stty` is required to test this command.

/home/runner/work/demo/demo/tests/Command/AddUserCommandTest.php:35

2) App\Tests\Command\AddUserCommandTest::testCreateUserNonInteractive with data set #1 (true)
`stty` is required to test this command.

/home/runner/work/demo/demo/tests/Command/AddUserCommandTest.php:35

3) App\Tests\Command\AddUserCommandTest::testCreateUserInteractive with data set #0 (false)
`stty` is required to test this command.

/home/runner/work/demo/demo/tests/Command/AddUserCommandTest.php:35

4) App\Tests\Command\AddUserCommandTest::testCreateUserInteractive with data set #1 (true)
`stty` is required to test this command.

/home/runner/work/demo/demo/tests/Command/AddUserCommandTest.php:35

OK, but incomplete, skipped, or risky tests!
Tests: 47, Assertions: 92, Skipped: 4.

Remaining indirect deprecation notices (1)

  1x: The "DAMA\DoctrineTestBundle\Doctrine\DBAL\AbstractStaticDriverV2" class implements "Doctrine\DBAL\Driver\ExceptionConverterDriver" that is deprecated.
    1x in PHPUnitExtension::executeBeforeFirstTest from DAMA\DoctrineTestBundle\PHPUnit
```

It would be good to run those tests at least on Ubuntu I think