### PR TITLE
Assets manifest is not necessary with Webpack Encore

### DIFF
--- a/config/packages/assets.yaml
+++ b/config/packages/assets.yaml
@@ -1,4 +1,2 @@
 framework:
-    assets:
-        json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'
-        strict_mode: '%kernel.debug%'
+    assets: ~


### PR DESCRIPTION
Fix breaking changes introduced by #1278

Asset urls generated in `entrypoints.json` https://github.com/symfony/demo/blob/a7a975e2938b0568b493406ce914ac0866b6dd58/public/build/entrypoints.json#L13  are not meant to be mapped with `manifest.json`
https://github.com/symfony/demo/blob/a7a975e2938b0568b493406ce914ac0866b6dd58/public/build/manifest.json#L2

The only place where the twig `asset` function is used, is for a file that is not in the manifest: https://github.com/symfony/demo/blob/a7a975e2938b0568b493406ce914ac0866b6dd58/templates/base.html.twig#L17