### PR TITLE
Leverage PHP 8 attributes to configure Command

### DIFF
--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Utils\Validator;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -46,12 +47,12 @@ use function Symfony\Component\String\u;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
+#[AsCommand(
+    name: 'app:add-user',
+    description: 'Creates users and stores them in the database'
+)]
 class AddUserCommand extends Command
 {
-    // to make your command lazily loaded, configure the $defaultName static property,
-    // so it will be instantiated only when the command is actually called.
-    protected static $defaultName = 'app:add-user';
-
     private SymfonyStyle $io;
 
     public function __construct(
@@ -69,7 +70,6 @@ class AddUserCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Creates users and stores them in the database')
             ->setHelp($this->getCommandHelp())
             // commands can optionally define arguments and/or options (mandatory and optional)
             // see https://symfony.com/doc/current/components/console/console_arguments.html

--- a/src/Command/DeleteUserCommand.php
+++ b/src/Command/DeleteUserCommand.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Utils\Validator;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -37,10 +38,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  * @author Oleg Voronkovich <oleg-voronkovich@yandex.ru>
  */
+#[AsCommand(
+    name: 'app:delete-user',
+    description: 'Deletes users from the database'
+)]
 class DeleteUserCommand extends Command
 {
-    protected static $defaultName = 'app:delete-user';
-
     private SymfonyStyle $io;
 
     public function __construct(
@@ -57,7 +60,6 @@ class DeleteUserCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Deletes users from the database')
             ->addArgument('username', InputArgument::REQUIRED, 'The username of an existing user')
             ->setHelp(<<<'HELP'
 The <info>%command.name%</info> command deletes users from the database:

--- a/src/Command/ListUsersCommand.php
+++ b/src/Command/ListUsersCommand.php
@@ -13,6 +13,7 @@ namespace App\Command;
 
 use App\Entity\User;
 use App\Repository\UserRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -37,11 +38,13 @@ use Symfony\Component\Mime\Email;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
+#[AsCommand(
+    name: 'app:list-users',
+    description: 'Lists all the existing users',
+    aliases: ['app:users']
+)]
 class ListUsersCommand extends Command
 {
-    // a good practice is to use the 'app:' prefix to group all your custom application commands
-    protected static $defaultName = 'app:list-users';
-
     public function __construct(
         private MailerInterface $mailer,
         private string $emailSender,
@@ -56,7 +59,6 @@ class ListUsersCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Lists all the existing users')
             ->setHelp(<<<'HELP'
 The <info>%command.name%</info> command lists all the users registered in the application:
 


### PR DESCRIPTION
I wanted to test PHP 8 install on my new machine, thus tried some features on this project as it now requires v8
I followed https://symfony.com/blog/new-in-symfony-5-3-lazy-command-description
Feel free to close, but I think it could be useful to showcase new way on this Symfony demo project as it is kind off an entry point, also Controllers uses this feature