### PR TITLE
Fix translator parameters

### DIFF
--- a/config/packages/translation.yaml
+++ b/config/packages/translation.yaml
@@ -1,6 +1,9 @@
+# See https://symfony.com/doc/current/translation.html
 framework:
     default_locale: '%locale%'
     translator:
+        # Translations are defined using the ICU Message Format
+        # See https://symfony.com/doc/current/translation/message_format.html
         default_path: '%kernel.project_dir%/translations'
         fallbacks:
             - '%locale%'

--- a/src/EventSubscriber/CommentNotificationSubscriber.php
+++ b/src/EventSubscriber/CommentNotificationSubscriber.php
@@ -52,8 +52,8 @@ class CommentNotificationSubscriber implements EventSubscriberInterface
 
         $subject = $this->translator->trans('notification.comment_created');
         $body = $this->translator->trans('notification.comment_created.description', [
-            '%title%' => $post->getTitle(),
-            '%link%' => $linkToPost,
+            'title' => $post->getTitle(),
+            'link' => $linkToPost,
         ]);
 
         // See https://symfony.com/doc/current/mailer.html

--- a/templates/admin/blog/edit.html.twig
+++ b/templates/admin/blog/edit.html.twig
@@ -3,7 +3,7 @@
 {% block body_id 'admin_post_edit' %}
 
 {% block main %}
-    <h1>{{ 'title.edit_post'|trans({'%id%': post.id}) }}</h1>
+    <h1>{{ 'title.edit_post'|trans({'id': post.id}) }}</h1>
 
     {{ include('admin/blog/_form.html.twig', {
         form: form,

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -13,13 +13,13 @@
 {% block body_id 'error' %}
 
 {% block main %}
-    <h1 class="text-danger">{{ 'http_error.name'|trans({ '%status_code%': status_code }) }}</h1>
+    <h1 class="text-danger">{{ 'http_error.name'|trans({ 'status_code': status_code }) }}</h1>
 
     <p class="lead">
-        {{ 'http_error.description'|trans({ '%status_code%': status_code }) }}
+        {{ 'http_error.description'|trans({ 'status_code': status_code }) }}
     </p>
     <p>
-        {{ 'http_error.suggestion'|trans({ '%url%': path('blog_index') })|raw }}
+        {{ 'http_error.suggestion'|trans({ 'url': path('blog_index') })|raw }}
     </p>
 {% endblock %}
 

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -13,7 +13,7 @@
 {% block body_id 'error' %}
 
 {% block main %}
-    <h1 class="text-danger"><i class="fa fa-unlock-alt" aria-hidden="true"></i> {{ 'http_error.name'|trans({ '%status_code%': 403 }) }}</h1>
+    <h1 class="text-danger"><i class="fa fa-unlock-alt" aria-hidden="true"></i> {{ 'http_error.name'|trans({ 'status_code': 403 }) }}</h1>
 
     <p class="lead">
         {{ 'http_error_403.description'|trans }}

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -13,13 +13,13 @@
 {% block body_id 'error' %}
 
 {% block main %}
-    <h1 class="text-danger">{{ 'http_error.name'|trans({ '%status_code%': 404 }) }}</h1>
+    <h1 class="text-danger">{{ 'http_error.name'|trans({ 'status_code': 404 }) }}</h1>
 
     <p class="lead">
         {{ 'http_error_404.description'|trans }}
     </p>
     <p>
-        {{ 'http_error_404.suggestion'|trans({ '%url%': path('blog_index') })|raw }}
+        {{ 'http_error_404.suggestion'|trans({ 'url': path('blog_index') })|raw }}
     </p>
 {% endblock %}
 

--- a/templates/bundles/TwigBundle/Exception/error500.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error500.html.twig
@@ -18,13 +18,13 @@
 {% block body_id 'error' %}
 
 {% block main %}
-    <h1 class="text-danger">{{ 'http_error.name'|trans({ '%status_code%': 500 }) }}</h1>
+    <h1 class="text-danger">{{ 'http_error.name'|trans({ 'status_code': 500 }) }}</h1>
 
     <p class="lead">
         {{ 'http_error_500.description'|trans }}
     </p>
     <p>
-        {{ 'http_error_500.suggestion'|trans({ '%url%': path('blog_index') })|raw }}
+        {{ 'http_error_500.suggestion'|trans({ 'url': path('blog_index') })|raw }}
     </p>
 {% endblock %}
 


### PR DESCRIPTION
Even if it works with`%var%` I think without is better, wdyt?
Ref https://symfony.com/doc/current/translation/message_format.html
Also added a direct link to doc