### PR TITLE
Fix an exception in CommentType

### DIFF
--- a/src/Form/CommentType.php
+++ b/src/Form/CommentType.php
@@ -43,7 +43,6 @@ class CommentType extends AbstractType
         $builder
             ->add('content', TextareaType::class, [
                 'help' => 'help.comment_content',
-                'formaction' => 'foo',
             ])
         ;
     }


### PR DESCRIPTION
Fixes:

An exception has been thrown during the rendering of a template ("An error has occurred resolving the options of the form "Symfony\Component\Form\Extension\Core\Type\TextareaType": The option "formaction" does not exist.