### PR TITLE
Disable password manager for the login form

### DIFF
--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -34,6 +34,16 @@
                             <i class="fa fa-sign-in" aria-hidden="true"></i> {{ 'action.sign_in'|trans }}
                         </button>
                     </fieldset>
+
+                    <!-- by default, modern browsers ask users to store passwords. This behavior is correct in
+                         real sites, but it's nonsensical in this demo project, where storing this password
+                         will result in unneeded security notifications about 'breached passwords'.
+                         Sadly it's not possible to change or disable this browser behavior (even 'autocomplete=off'
+                         doesn't work). That's why we use the trick of adding many password fields to the form
+                         (only one of them is real and the ones below are unused by the application). When a form
+                         includes many password fields, browsers no longer ask to store the password.  -->
+                    <input type="password" id="disable-password-manager-1" style="display: none;" value="stop-password-manager-1"/>
+                    <input type="password" id="disable-password-manager-2" style="display: none;" value="stop-password-manager-2"/>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
Today I received a new security notification from Google saying that some passwords of mine were breached ... they were the passwords of this Symfony Demo application. It's not the first time, so I looked for possible solutions to prevent storing this password.

Apparently it's impossible to do it with the autocomplete attribute (https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) because modern browsers don't respect it when set to `off` in a password field.

So, I used the solution explained here:
https://stackoverflow.com/questions/41945535/html-disable-password-manager/41946532

I've tested this solution successfully with both Chrome and Firefox. What do you think?