### PR TITLE
Remove the dependency on composer/package-versions-deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "require": {
         "php": ">=8.0.2",
         "ext-pdo_sqlite": "*",
-        "composer/package-versions-deprecated": "^1.8",
         "doctrine/dbal": "^3.1",
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/doctrine-migrations-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0e217f576c3471c9c286030f9a36d5b",
+    "content-hash": "e0ca67774f9360837a304cd301e06e54",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",


### PR DESCRIPTION
This package was added in the past to force keeping support for composer 1 when using doctrine/orm. In the meantime, doctrine/orm has switched to using that package directly, making this root requirement useless. And in the next releases of doctrine/orm and doctrine/dbal, they are migrating to use composer-runtime-api (dropping support for composer 1) instead of using this plugin, as part of the effort to fade out that compat plugin.

Refs https://github.com/symfony/symfony/issues/44726

The package is still present for now (and so still needed in the list of allowed plugins too) because doctrine packages require it. But this will change in their next releases for DBAL, ORM and Migrations (the PRs are already merged)