### PR TITLE
Use logout_path() helper + add CSRF protection to logout

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -50,6 +50,10 @@ security:
                 # The name of the route to redirect to after logging out
                 target: homepage
 
+                # Secure the logout against CSRF
+                csrf_parameter: logout
+                csrf_token_generator: security.csrf.token_manager
+
             # needed because in tests we redefine the 'main' firewall to use
             # HTTP Basic instead of the login form, so this firewall has
             # multiple authenticators

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -83,7 +83,7 @@
                                             </li>
                                             <li class="divider"></li>
                                             <li>
-                                                <a href="{{ path('security_logout') }}">
+                                                <a href="{{ logout_path() }}">
                                                     <i class="fa fa-sign-out" aria-hidden="true"></i> {{ 'menu.logout'|trans }}
                                                 </a>
                                             </li>


### PR DESCRIPTION
The login form already had CSRF protection, but logout didn't yet in this demo application. Generally, I think it's a good idea to add CSRF protection to logout. At the very least, it avoids annoying situations where a website can force users to logout from your service on each visit. But depending on the type of application, things can also get more serious and cause actual security issues when CSRF on logout isn't enabled.

Fortunately, CSRF protection on logout is quite easy using the `logout_path()` helper: it automatically knows the logout URL of the current firewall and it automatically adds the correct CSRF token to the URL. I think the logout path/url helpers are little known gems in Symfony, so let's showcase them :)