### PR TITLE
Update PHP doc about annotations IsGranted

### DIFF
--- a/src/Controller/Admin/BlogController.php
+++ b/src/Controller/Admin/BlogController.php
@@ -112,7 +112,7 @@ class BlogController extends AbstractController
     public function show(Post $post): Response
     {
         // This security check can also be performed
-        // using an annotation: @IsGranted("show", subject="post", message="Posts can only be shown to their authors.")
+        // using a PHP attribute: #[IsGranted('show', subject: 'post', message: 'Posts can only be shown to their authors.')]
         $this->denyAccessUnlessGranted(PostVoter::SHOW, $post, 'Posts can only be shown to their authors.');
 
         return $this->render('admin/blog/show.html.twig', [


### PR DESCRIPTION
The doc now suggests to use PHP attributes instead of "old" annotation for "IsGranted" instruction.
Sorry if my PR format doesn't match with your requirements. I just wanna help. :)