### PR TITLE
Use stderr for logging in prod

### DIFF
--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -8,7 +8,7 @@ monolog:
             buffer_size: 50 # How many messages should be saved? Prevent memory leaks
         nested:
             type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            path: php://stderr
             level: debug
             formatter: monolog.formatter.json
         console:


### PR DESCRIPTION
Using stderr in prod by default is a good idea (we made the change in the official recipe a while ago -- https://github.com/symfony/recipes/blob/master/symfony/monolog-bundle/3.7/config/packages/monolog.yaml#L51) as it makes it work out of the box with anything compatible with Docker, including Platform.sh.