### PR TITLE
use nullsafe operator in BlogController

### DIFF
--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -59,7 +59,7 @@ class BlogController extends AbstractController
         // See https://symfony.com/doc/current/templates.html#template-naming
         return $this->render('blog/index.'.$_format.'.twig', [
             'paginator' => $latestPosts,
-            'tagName' => $tag ? $tag->getName() : null,
+            'tagName' => $tag?->getName(),
         ]);
     }
 


### PR DESCRIPTION
Hi,

Considering symfony/demo require php 8.0.2 I guess it'safe to use nullsafe instead ternary to get tag's name if `Tag` exist