### PR TITLE
Added "remember me" feature in the login form

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -44,6 +44,15 @@ security:
                 # session (for example when the users access directly to the login page).
                 default_target_path: blog_index
 
+            # Reference: https://symfony.com/doc/current/security/remember_me.html
+            remember_me:
+                secret:   '%kernel.secret%' # required
+                lifetime: 604800 # 1 week in seconds
+                # by default, the feature is enabled by checking a
+                # checkbox in the login form (see below), uncomment the
+                # following line to always enable it.
+                #always_remember_me: true
+
             logout:
                 # The route name the user can go to in order to logout
                 path: security_logout

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -28,6 +28,12 @@
                             <label for="password">{{ 'label.password'|trans }}</label>
                             <input type="password" id="password" name="_password" class="form-control" />
                         </div>
+                        <div class="form-group">
+                            <label>
+                                <input type="checkbox" name="_remember_me" checked/>
+                                Keep me logged in
+                            </label>
+                        </div>
                         <input type="hidden" name="_target_path" value="{{ app.request.get('redirect_to') }}"/>
                         <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}"/>
                         <button type="submit" class="btn btn-primary">


### PR DESCRIPTION
"Remember me" is a common functionality in login forms and I noticed that the demo application does not have it.

This PR is a small change and any user can easily find that in the documentation, but I believe that this is still a relevant addition in order to make this demo a bit more "complete" and show that Symfony can provide common functionalities out of the box.

I also didn't find any discussion (issue/pr) about this functionality so I don't know whether it was intended to not have it in the demo app.

What do you think?