### PR TITLE
Use 'composer audit' instead of 'symfony check:security'

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -86,13 +86,9 @@ jobs:
               if: always() && steps.install.outcome == 'success'
               run: composer validate --strict
 
-            - name: Download Symfony CLI
-              if: always() && steps.install.outcome == 'success'
-              run: wget https://get.symfony.com/cli/installer -O - | bash
-
             - name: Check if any dependencies are compromised
               if: always() && steps.install.outcome == 'success'
-              run: /home/runner/.symfony5/bin/symfony check:security
+              run: composer audit
 
             - name: Run PHPStan
               if: always() && steps.install.outcome == 'success'


### PR DESCRIPTION
Since Composer 2.4, there is a new command called audit, that outputs a list of reported security vulnerabilities for the list of packages versions currently installed.

This removes the need to download and install Symfony CLI
