### PR TITLE
CI: Remove "Require symfony/flex" step from tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,9 +58,6 @@ jobs:
                   key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ hashFiles('composer.json') }}
                   restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
 
-            - name: "Require symfony/flex"
-              run: composer require --no-progress --no-scripts --no-plugins symfony/flex
-
             - name: "Install dependencies"
               run: composer update --no-interaction --prefer-dist --optimize-autoloader
 


### PR DESCRIPTION
I think this step can be remove since "symfony/flex" is already part of the project dependencies.

https://github.com/symfony/demo/blob/v2.2.0/composer.json#L28
