### PR TITLE
Remove composer/package-versions-deprecated from allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,18 +59,17 @@
         "symfony/web-profiler-bundle": "^6.2"
     },
     "config": {
+        "allow-plugins": {
+            "symfony/flex": true,
+            "symfony/runtime": true
+        },
         "platform": {
             "php": "8.1.0"
         },
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true,
-        "allow-plugins": {
-            "composer/package-versions-deprecated": true,
-            "symfony/flex": true,
-            "symfony/runtime": true
-        }
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The plugin composer/package-versions-deprecated is no longer in use.

Followup of #1310 