### PR TITLE
[Sf62] Use the new 'hash_property_path' option of the PasswordType field

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -12,13 +12,12 @@
 namespace App\Controller;
 
 use App\Entity\User;
-use App\Form\Type\ChangePasswordType;
+use App\Form\ChangePasswordType;
 use App\Form\UserType;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -61,17 +60,12 @@ class UserController extends AbstractController
     public function changePassword(
         #[CurrentUser] User $user,
         Request $request,
-        UserPasswordHasherInterface $passwordHasher,
         EntityManagerInterface $entityManager,
     ): Response {
-        $form = $this->createForm(ChangePasswordType::class);
+        $form = $this->createForm(ChangePasswordType::class, $user);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            /** @var string $plainPassword */
-            $plainPassword = $form->get('newPassword')->getData();
-
-            $user->setPassword($passwordHasher->hashPassword($user, $plainPassword));
             $entityManager->flush();
 
             return $this->redirectToRoute('security_logout');

--- a/src/Form/ChangePasswordType.php
+++ b/src/Form/ChangePasswordType.php
@@ -9,18 +9,20 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Form\Type;
+namespace App\Form;
 
+use App\Entity\User;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
- * Defines the custom form field type used to change user's password.
+ * Defines the form used to change user's password.
  *
  * @author Romain Monteil <monteil.romain@gmail.com>
  */
@@ -37,6 +39,7 @@ class ChangePasswordType extends AbstractType
                     new UserPassword(),
                 ],
                 'label' => 'label.current_password',
+                'mapped' => false,
                 'attr' => [
                     'autocomplete' => 'off',
                 ],
@@ -51,12 +54,24 @@ class ChangePasswordType extends AbstractType
                     ),
                 ],
                 'first_options' => [
+                    'hash_property_path' => 'password',
                     'label' => 'label.new_password',
                 ],
+                'mapped' => false,
                 'second_options' => [
                     'label' => 'label.new_password_confirm',
                 ],
             ])
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+        ]);
     }
 }


### PR DESCRIPTION
https://symfony.com/blog/new-in-symfony-6-2-security-improvements-part-2#improved-password-form-field

Fixes #1378 