### PR TITLE
Limit page size to prevent integer overflow

### DIFF
--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -46,7 +46,7 @@ class BlogController extends AbstractController
      */
     #[Route('/', defaults: ['page' => '1', '_format' => 'html'], methods: ['GET'], name: 'blog_index')]
     #[Route('/rss.xml', defaults: ['page' => '1', '_format' => 'xml'], methods: ['GET'], name: 'blog_rss')]
-    #[Route('/page/{page<[1-9]\d*>}', defaults: ['_format' => 'html'], methods: ['GET'], name: 'blog_index_paginated')]
+    #[Route('/page/{page<[1-9]\d{0,8}>}', defaults: ['_format' => 'html'], methods: ['GET'], name: 'blog_index_paginated')]
     #[Cache(smaxage: 10)]
     public function index(Request $request, int $page, string $_format, PostRepository $posts, TagRepository $tags): Response
     {


### PR DESCRIPTION
The $param is typed int. So if the routing param does not fit into an int, PHP will throw a TypeError. This in turn would trigger an 500 internal server error. So by requesting a too big page, e.g. `/de/blog/page/147483647147483647147483647`, one can trigger internal errors which should not be possible.

I don't think there is an easy solution to this general problem that Symfony could automatically provide. So the best solution seems to be to limit the size of the routing placeholder. With this limit the page will always fit into an int even on a 32-bit platform.