### PR TITLE
cleanup: use roles constants

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8153,16 +8153,16 @@
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "1.3.35",
+            "version": "1.3.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "3dbb999bd56cc21d6733bab60898ebdf388245b5"
+                "reference": "8c22f2499444897941f9162c25f8538217c16f15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/3dbb999bd56cc21d6733bab60898ebdf388245b5",
-                "reference": "3dbb999bd56cc21d6733bab60898ebdf388245b5",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/8c22f2499444897941f9162c25f8538217c16f15",
+                "reference": "8c22f2499444897941f9162c25f8538217c16f15",
                 "shasum": ""
             },
             "require": {
@@ -8217,9 +8217,9 @@
             "description": "Doctrine extensions for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
-                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.3.35"
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.3.36"
             },
-            "time": "2023-03-10T14:43:05+00:00"
+            "time": "2023-03-15T15:10:43+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -69,6 +69,7 @@ security:
         # additional security lives in the controllers
         - { path: '^/(%app_locales%)/admin', roles: ROLE_ADMIN }
 
+    # The ROLE_ADMIN role inherits from the ROLE_USER role
     role_hierarchy:
         ROLE_ADMIN: ROLE_USER
 

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -189,7 +189,7 @@ class AddUserCommand extends Command
         $user->setFullName($fullName);
         $user->setUsername($username);
         $user->setEmail($email);
-        $user->setRoles([$isAdmin ? 'ROLE_ADMIN' : 'ROLE_USER']);
+        $user->setRoles([$isAdmin ? User::ROLE_ADMIN : User::ROLE_USER]);
 
         // See https://symfony.com/doc/5.4/security.html#registering-the-user-hashing-passwords
         $hashedPassword = $this->passwordHasher->hashPassword($user, $plainPassword);

--- a/src/Controller/Admin/BlogController.php
+++ b/src/Controller/Admin/BlogController.php
@@ -38,7 +38,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 #[Route('/admin/post')]
-#[IsGranted('ROLE_ADMIN')]
+#[IsGranted(User::ROLE_ADMIN)]
 class BlogController extends AbstractController
 {
     /**

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -31,7 +31,7 @@ use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
  *
  * @author Romain Monteil <monteil.romain@gmail.com>
  */
-#[Route('/profile'), IsGranted('ROLE_USER')]
+#[Route('/profile'), IsGranted(User::ROLE_USER)]
 class UserController extends AbstractController
 {
     #[Route('/edit', name: 'user_edit', methods: ['GET', 'POST'])]

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -103,9 +103,9 @@ class AppFixtures extends Fixture
     {
         return [
             // $userData = [$fullname, $username, $password, $email, $roles];
-            ['Jane Doe', 'jane_admin', 'kitten', 'jane_admin@symfony.com', ['ROLE_ADMIN']],
-            ['Tom Doe', 'tom_admin', 'kitten', 'tom_admin@symfony.com', ['ROLE_ADMIN']],
-            ['John Doe', 'john_user', 'kitten', 'john_user@symfony.com', ['ROLE_USER']],
+            ['Jane Doe', 'jane_admin', 'kitten', 'jane_admin@symfony.com', [User::ROLE_ADMIN]],
+            ['Tom Doe', 'tom_admin', 'kitten', 'tom_admin@symfony.com', [User::ROLE_ADMIN]],
+            ['John Doe', 'john_user', 'kitten', 'john_user@symfony.com', [User::ROLE_USER]],
         ];
     }
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -32,6 +32,12 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Table(name: 'symfony_demo_user')]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
+    // We can use constants for roles to find usages all over the application rather
+    // than doing a full-text search on the "ROLE_" string.
+    // It also prevents from making typo errors.
+    final public const ROLE_USER = 'ROLE_USER';
+    final public const ROLE_ADMIN = 'ROLE_ADMIN';
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
@@ -118,7 +124,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
         // guarantees that a user always has at least one role for security
         if (empty($roles)) {
-            $roles[] = 'ROLE_USER';
+            $roles[] = self::ROLE_USER;
         }
 
         return array_unique($roles);


### PR DESCRIPTION
Before we had to hard-code roles strings: 

```
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;

class PostController extends Controller
{
    /**
     * @IsGranted("ROLE_ADMIN")
     *
     * or use @Security for more flexibility:
     *
     * @Security("is_granted('ROLE_ADMIN') and is_granted('ROLE_FRIENDLY_USER')")
     */
    public function index()
    {
        // ...
    }
}
```

But with attributes, can use constants. I find this cleaner. I have already used this on several projects and I didn't find drawbacks.