### PR TITLE
Use `#[MapRequestPayload]` for admin blog controller

### DIFF
--- a/src/Controller/Admin/BlogController.php
+++ b/src/Controller/Admin/BlogController.php
@@ -11,6 +11,7 @@
 
 namespace App\Controller\Admin;
 
+use App\Dto\DeletePostPayload;
 use App\Entity\Post;
 use App\Entity\User;
 use App\Form\PostType;
@@ -22,6 +23,7 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\SubmitButton;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -159,12 +161,9 @@ final class BlogController extends AbstractController
      */
     #[Route('/{id}/delete', name: 'admin_post_delete', methods: ['POST'])]
     #[IsGranted('delete', subject: 'post')]
-    public function delete(Request $request, Post $post, EntityManagerInterface $entityManager): Response
+    public function delete(#[MapRequestPayload] DeletePostPayload $deletePostPayload, Post $post, EntityManagerInterface $entityManager): Response
     {
-        /** @var string|null $token */
-        $token = $request->request->get('token');
-
-        if (!$this->isCsrfTokenValid('delete', $token)) {
+        if (!$this->isCsrfTokenValid('delete', $deletePostPayload->token)) {
             return $this->redirectToRoute('admin_post_index');
         }
 

--- a/src/Dto/DeletePostPayload.php
+++ b/src/Dto/DeletePostPayload.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class DeletePostPayload
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        public readonly string $token,
+    ) {
+    }
+}

--- a/src/Dto/DeletePostPayload.php
+++ b/src/Dto/DeletePostPayload.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Dto;
 
 use Symfony\Component\Validator\Constraints as Assert;


### PR DESCRIPTION
Fix #1434

Unfortunately there is no Rest endpoints in the demo, I think it would have been more interesting to use it then.