### PR TITLE
Using Doctrine LifecycleCallbacks

### DIFF
--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -30,8 +30,9 @@ use function Symfony\Component\String\u;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Mecanik <contact@mecanik.dev>
  */
-#[ORM\Entity, HasLifecycleCallbacks]
+#[ORM\Entity]
 #[ORM\Table(name: 'symfony_demo_comment')]
+#[HasLifecycleCallbacks]
 class Comment
 {
     #[ORM\Id]

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -13,6 +13,9 @@ namespace App\Entity;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\HasLifecycleCallbacks;
+use Doctrine\ORM\Mapping\PrePersist;
+use Doctrine\ORM\Mapping\PreUpdate;
 use Symfony\Component\Validator\Constraints as Assert;
 use function Symfony\Component\String\u;
 
@@ -25,8 +28,9 @@ use function Symfony\Component\String\u;
  *
  * @author Ryan Weaver <weaverryan@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ * @author Mecanik <contact@mecanik.dev>
  */
-#[ORM\Entity]
+#[ORM\Entity, HasLifecycleCallbacks]
 #[ORM\Table(name: 'symfony_demo_comment')]
 class Comment
 {
@@ -51,6 +55,12 @@ class Comment
     #[ORM\JoinColumn(nullable: false)]
     private ?User $author = null;
 
+    #[ORM\Column(type: 'datetime_immutable')]
+    private $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private $updatedAt;
+	
     public function __construct()
     {
         $this->publishedAt = new \DateTime();
@@ -107,5 +117,41 @@ class Comment
     public function setPost(Post $post): void
     {
         $this->post = $post;
+    }
+	
+	public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+	
+	#[PrePersist]
+    #[PreUpdate]
+    public function updatedTimestamps()
+    {
+        if ($this->getUpdatedAt() == null) {
+            $this->setUpdatedAt(new \DateTimeImmutable('now'));
+        }
+        if ($this->getCreatedAt() == null) {
+            $this->setCreatedAt(new \DateTimeImmutable('now'));
+        }
     }
 }

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -35,9 +35,10 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  * @author Mecanik <contact@mecanik.dev>
  */
-#[ORM\Entity(repositoryClass: PostRepository::class), HasLifecycleCallbacks]
+#[ORM\Entity(repositoryClass: PostRepository::class)]
 #[ORM\Table(name: 'symfony_demo_post')]
 #[UniqueEntity(fields: ['slug'], errorPath: 'title', message: 'post.slug_unique')]
+#[HasLifecycleCallbacks]
 class Post
 {
     #[ORM\Id]

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -25,8 +25,9 @@ use Doctrine\ORM\Mapping\PreUpdate;
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  * @author Mecanik <contact@mecanik.dev>
  */
-#[ORM\Entity, HasLifecycleCallbacks]
+#[ORM\Entity]
 #[ORM\Table(name: 'symfony_demo_tag')]
+#[HasLifecycleCallbacks]
 class Tag implements \JsonSerializable
 {
     #[ORM\Id]

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -13,6 +13,9 @@ namespace App\Entity;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\HasLifecycleCallbacks;
+use Doctrine\ORM\Mapping\PrePersist;
+use Doctrine\ORM\Mapping\PreUpdate;
 
 /**
  * Defines the properties of the Tag entity to represent the post tags.
@@ -20,8 +23,9 @@ use Doctrine\ORM\Mapping as ORM;
  * See https://symfony.com/doc/current/doctrine.html#creating-an-entity-class
  *
  * @author Yonel Ceruto <yonelceruto@gmail.com>
+ * @author Mecanik <contact@mecanik.dev>
  */
-#[ORM\Entity]
+#[ORM\Entity, HasLifecycleCallbacks]
 #[ORM\Table(name: 'symfony_demo_tag')]
 class Tag implements \JsonSerializable
 {
@@ -33,6 +37,12 @@ class Tag implements \JsonSerializable
     #[ORM\Column(type: Types::STRING, unique: true)]
     private readonly string $name;
 
+    #[ORM\Column(type: 'datetime_immutable')]
+    private $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private $updatedAt;
+	
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -60,5 +70,41 @@ class Tag implements \JsonSerializable
     public function __toString(): string
     {
         return $this->name;
+    }
+	
+	public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+	
+	#[PrePersist]
+    #[PreUpdate]
+    public function updatedTimestamps()
+    {
+        if ($this->getUpdatedAt() == null) {
+            $this->setUpdatedAt(new \DateTimeImmutable('now'));
+        }
+        if ($this->getCreatedAt() == null) {
+            $this->setCreatedAt(new \DateTimeImmutable('now'));
+        }
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -32,8 +32,9 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Mecanik <contact@mecanik.dev>
  */
-#[ORM\Entity(repositoryClass: UserRepository::class), HasLifecycleCallbacks]
+#[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: 'symfony_demo_user')]
+#[HasLifecycleCallbacks]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     // We can use constants for roles to find usages all over the application rather

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -14,6 +14,9 @@ namespace App\Entity;
 use App\Repository\UserRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\HasLifecycleCallbacks;
+use Doctrine\ORM\Mapping\PrePersist;
+use Doctrine\ORM\Mapping\PreUpdate;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -27,8 +30,9 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Ryan Weaver <weaverryan@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ * @author Mecanik <contact@mecanik.dev>
  */
-#[ORM\Entity(repositoryClass: UserRepository::class)]
+#[ORM\Entity(repositoryClass: UserRepository::class), HasLifecycleCallbacks]
 #[ORM\Table(name: 'symfony_demo_user')]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
@@ -59,6 +63,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: Types::STRING)]
     private ?string $password = null;
 
+    #[ORM\Column(type: 'datetime_immutable')]
+    private $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private $updatedAt;
+	
     /**
      * @var string[]
      */
@@ -179,5 +189,41 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     {
         // add $this->salt too if you don't use Bcrypt or Argon2i
         [$this->id, $this->username, $this->password] = $data;
+    }
+	
+	public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+	
+	#[PrePersist]
+    #[PreUpdate]
+    public function updatedTimestamps()
+    {
+        if ($this->getUpdatedAt() == null) {
+            $this->setUpdatedAt(new \DateTimeImmutable('now'));
+        }
+        if ($this->getCreatedAt() == null) {
+            $this->setCreatedAt(new \DateTimeImmutable('now'));
+        }
     }
 }


### PR DESCRIPTION
This is the modern solution to automatically update timestamps in Doctrine. I have added `createdAt` and `updatedAt` to all entities using [LifecycleCallbacks](https://www.doctrine-project.org/projects/doctrine-orm/en/2.16/reference/events.html#lifecycle-callbacks).