### PR TITLE
Show invisible alerts (fix #1440)

### DIFF
--- a/templates/default/_flash_messages.html.twig
+++ b/templates/default/_flash_messages.html.twig
@@ -19,7 +19,7 @@
         {% for type, messages in app.flashes %}
             {% for message in messages %}
                 {# Bootstrap alert, see https://getbootstrap.com/docs/3.4/components/#alerts #}
-                <div class="alert alert-dismissible alert-{{ type }} fade in" role="alert">
+                <div class="alert alert-dismissible alert-{{ type }} fade show" role="alert">
                     <button type="button" class="close" data-dismiss="alert" aria-label="{{ 'action.close'|trans }}">
                         <span aria-hidden="true">&times;</span>
                     </button>


### PR DESCRIPTION
Add class "show" to avoid invisible alerts 

See https://github.com/symfony/demo/issues/1440 