### PR TITLE
Fix comment stating isSubmitted is optional

### DIFF
--- a/src/Controller/Admin/BlogController.php
+++ b/src/Controller/Admin/BlogController.php
@@ -86,9 +86,8 @@ final class BlogController extends AbstractController
 
         $form->handleRequest($request);
 
-        // the isSubmitted() method is completely optional because the other
-        // isValid() method already checks whether the form is submitted.
-        // However, we explicitly add it to improve code readability.
+        // The isSubmitted() call is mandatory because the isValid() method
+        // throws an exception if the form has not been submitted.
         // See https://symfony.com/doc/current/forms.html#processing-forms
         if ($form->isSubmitted() && $form->isValid()) {
             $entityManager->persist($post);


### PR DESCRIPTION
The isSubmitted() _must_ be called before

[src/Symfony/Component/Form/Form.php](https://github.com/symfony/symfony/blob/6637b78a4fcba7cef818f2a022e096d503690ac5/src/Symfony/Component/Form/Form.php#L646-L657)
```php

    public function isValid(): bool
    {
        if (!$this->submitted) {
            throw new LogicException('Cannot check if an unsubmitted form is valid. Call Form::isSubmitted() and ensure that it\'s true before calling Form::isValid().');
        }

        if ($this->isDisabled()) {
            return true;
        }

        return 0 === \count($this->getErrors(true));
    }
 ```


