### PR TITLE
Add notice to messenger for async code

### DIFF
--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -123,6 +123,9 @@ final class BlogController extends AbstractController
             // passed in the event and they can even modify the execution flow, so
             // there's no guarantee that the rest of this controller will be executed.
             // See https://symfony.com/doc/current/components/event_dispatcher.html
+            // You can also leverage the Symfony Messenger component if you need
+            // some asynchronous operations.
+            // See https://symfony.com/doc/current/messenger.html
             $eventDispatcher->dispatch(new CommentCreatedEvent($comment));
 
             return $this->redirectToRoute('blog_post', ['slug' => $post->getSlug()]);


### PR DESCRIPTION
While reading this, I found that pointing messenger here can be valuable (logic of decoupling)
Also, reading the code itself of the dispatch, I remind my old PR https://github.com/symfony/symfony-docs/pull/17035
there is no doc referencing the new `->dispatch(new ClassName())` as far as I see in https://symfony.com/doc/current/components/event_dispatcher.html#dispatch-the-event