### PR TITLE
Enable backtraces in Doctrine profiler

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -43,3 +43,8 @@ when@prod:
                     adapter: cache.app
                 doctrine.system_cache_pool:
                     adapter: cache.system
+
+when@dev:
+    doctrine:
+        dbal:
+            profiling_collect_backtrace: true


### PR DESCRIPTION
I didn't know about this feature. It's very useful to find the origin of a specific query from the doctrine profiler panel.

I think it's a good idea to activate it on symfony/demo, as it allows you to demonstrate this functionality.

<img width="971" alt="image" src="https://github.com/symfony/demo/assets/400034/6aec0f4f-cbf2-4b99-9837-96a9a53c9666">
