### PR TITLE
Use `#[Autowire]` attribute instead of Yaml config

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -17,7 +17,6 @@ services:
         bind:               # defines the scalar arguments once and apply them to any service defined/created in this file
             string $locales: '%app_locales%'
             string $defaultLocale: '%locale%'
-            string $emailSender: '%app.notifications.email_sender%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
@@ -27,10 +26,3 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
-
-    # when the service definition only contains arguments, you can omit the
-    # 'arguments' key and define the arguments just below the service class
-    App\EventSubscriber\CommentNotificationSubscriber:
-        $sender: '%app.notifications.email_sender%'
-
-    Symfony\Component\Security\Http\Logout\LogoutUrlGenerator: '@security.logout_url_generator'

--- a/src/Command/ListUsersCommand.php
+++ b/src/Command/ListUsersCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 
@@ -47,6 +48,7 @@ final class ListUsersCommand extends Command
 {
     public function __construct(
         private readonly MailerInterface $mailer,
+        #[Autowire('%app.notifications.email_sender%')]
         private readonly string $emailSender,
         private readonly UserRepository $users
     ) {

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -16,6 +16,7 @@ use App\Form\ChangePasswordType;
 use App\Form\UserType;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -62,6 +63,7 @@ final class UserController extends AbstractController
         #[CurrentUser] User $user,
         Request $request,
         EntityManagerInterface $entityManager,
+        #[Autowire('@security.logout_url_generator')]
         LogoutUrlGenerator $logoutUrlGenerator,
     ): Response {
         $form = $this->createForm(ChangePasswordType::class, $user);

--- a/src/EventSubscriber/CommentNotificationSubscriber.php
+++ b/src/EventSubscriber/CommentNotificationSubscriber.php
@@ -14,6 +14,7 @@ namespace App\EventSubscriber;
 use App\Entity\Post;
 use App\Entity\User;
 use App\Event\CommentCreatedEvent;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
@@ -31,6 +32,7 @@ final class CommentNotificationSubscriber implements EventSubscriberInterface
         private readonly MailerInterface $mailer,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly TranslatorInterface $translator,
+        #[Autowire('%app.notifications.email_sender%')]
         private readonly string $sender
     ) {
     }


### PR DESCRIPTION
I'm not sure this is something you want to do: replacing Yaml config for attribute for class alias, to use the `#[Autowire]` attribute available [since Symfony 6.1](https://symfony.com/blog/new-in-symfony-6-1-service-autowiring-attributes).

I did the change, so let you decide if that's good or not for the demo.