### PR TITLE
Use `Security::logout()` instead of redirecting to the logout url

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,6 +29,3 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
-
-    # this is needed because Symfony doesn't make the 'security.logout_url_generator' service autowirable
-    Symfony\Component\Security\Http\Logout\LogoutUrlGenerator: '@security.logout_url_generator'

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -16,12 +16,12 @@ use App\Form\ChangePasswordType;
 use App\Form\UserType;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
 /**
  * Controller used to manage current user. The #[CurrentUser] attribute
@@ -62,7 +62,7 @@ final class UserController extends AbstractController
         #[CurrentUser] User $user,
         Request $request,
         EntityManagerInterface $entityManager,
-        LogoutUrlGenerator $logoutUrlGenerator,
+        Security $security,
     ): Response {
         $form = $this->createForm(ChangePasswordType::class, $user);
         $form->handleRequest($request);
@@ -70,7 +70,9 @@ final class UserController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $entityManager->flush();
 
-            return $this->redirect($logoutUrlGenerator->getLogoutPath());
+            // The logout method has a protection against CSRF attacks, it's disabled here
+            // because the form already has a CSRF token validated.
+            return $security->logout(false);
         }
 
         return $this->render('user/change_password.html.twig', [

--- a/tests/Controller/UserControllerTest.php
+++ b/tests/Controller/UserControllerTest.php
@@ -103,9 +103,9 @@ final class UserControllerTest extends WebTestCase
         ]);
 
         $this->assertResponseRedirects();
-        $this->assertStringStartsWith(
-            '/logout',
-            $client->getResponse()->headers->get('Location') ?? '',
+        $this->assertResponseRedirects(
+            '/',
+            Response::HTTP_FOUND,
             'Changing password logout the user.'
         );
     }


### PR DESCRIPTION
Proposition from @chalasr: https://github.com/symfony/symfony/pull/52833#issuecomment-1839135127

The logout URL generator should be used to create links with CSRF protection. In this case, the action is already secured by the form, the redirection is not necessary.