### PR TITLE
CI: Share composer cache across php versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,11 +52,11 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ hashFiles('composer.lock') }}
-                  restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
+                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
 
-            - name: "Composer install"
-              run: composer install --no-interaction --no-progress
+            - name: "Install dependencies"
+              run: composer install --ansi --no-interaction --no-progress
 
             - name: Install PHPUnit
               id: install

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,11 +55,11 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ hashFiles('composer.json') }}
-                  restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
+                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
 
             - name: "Install dependencies"
-              run: composer install --no-interaction --no-progress
+              run: composer install --ansi --no-interaction --no-progress
 
             - name: "Install PHPUnit"
               run: vendor/bin/simple-phpunit install


### PR DESCRIPTION
Composer installs the dependencies from a composer.lock file 

The result doesn't depend on the PHP version that is used in CI