### PR TITLE
Add a missing command to build Sass files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,8 @@
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd",
-            "importmap:install": "symfony-cmd"
+            "importmap:install": "symfony-cmd",
+            "sass:build": "symfony-cmd"
         },
         "post-install-cmd": [
             "@auto-scripts"


### PR DESCRIPTION
After merging #1449 I saw this error when running the app:

![image](https://github.com/symfony/demo/assets/73419/5969dde6-0ecf-4ed4-bd37-14084371c2e4)

