### PR TITLE
Add a subtle cross-fade view transition

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -8,6 +8,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="view-transition" content="same-origin" />
         <title>{% block title %}Symfony Demo application{% endblock %}</title>
         <link rel="alternate" type="application/rss+xml" title="{{ 'rss.title'|trans }}" href="{{ path('blog_rss') }}">
 


### PR DESCRIPTION
On symfony.com we recently added some subtle [CSS view transitions](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API).

I propose to add this little change that adds a very subtle cross-fade animation between page loads. For now, it only works on Google Chrome browsers.