### PR TITLE
More consistent code style

### DIFF
--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -138,6 +138,7 @@ final class AddUserCommand extends Command
 
         // Ask for the email if it's not defined
         $email = $input->getArgument('email');
+
         if (null !== $email) {
             $this->io->text(' > <info>Email</info>: '.$email);
         } else {
@@ -147,6 +148,7 @@ final class AddUserCommand extends Command
 
         // Ask for the full name if it's not defined
         $fullName = $input->getArgument('full-name');
+
         if (null !== $fullName) {
             $this->io->text(' > <info>Full Name</info>: '.$fullName);
         } else {
@@ -198,6 +200,7 @@ final class AddUserCommand extends Command
         $this->io->success(sprintf('%s was successfully created: %s (%s)', $isAdmin ? 'Administrator user' : 'User', $user->getUsername(), $user->getEmail()));
 
         $event = $stopwatch->stop('add-user-command');
+
         if ($output->isVerbose()) {
             $this->io->comment(sprintf('New user database id: %d / Elapsed time: %.2f ms / Consumed memory: %.2f MB', $user->getId(), $event->getDuration(), $event->getMemory() / (1024 ** 2)));
         }

--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -51,9 +51,11 @@ final class BlogController extends AbstractController
     public function index(Request $request, int $page, string $_format, PostRepository $posts, TagRepository $tags): Response
     {
         $tag = null;
+
         if ($request->query->has('tag')) {
             $tag = $tags->findOneBy(['name' => $request->query->get('tag')]);
         }
+
         $latestPosts = $posts->findLatest($page, $tag);
 
         // Every template name also has two extensions that specify the format and

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -135,6 +135,7 @@ final class AppFixtures extends Fixture
     private function getPostData(): array
     {
         $posts = [];
+
         foreach ($this->getPhrases() as $i => $title) {
             // $postData = [$title, $slug, $summary, $content, $publishedAt, $author, $tags, $comments];
 

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -154,6 +154,7 @@ class Post
     public function addComment(Comment $comment): void
     {
         $comment->setPost($this);
+
         if (!$this->comments->contains($comment)) {
             $this->comments->add($comment);
         }

--- a/src/EventSubscriber/CommentNotificationSubscriber.php
+++ b/src/EventSubscriber/CommentNotificationSubscriber.php
@@ -63,6 +63,7 @@ final class CommentNotificationSubscriber implements EventSubscriberInterface
         ], UrlGeneratorInterface::ABSOLUTE_URL);
 
         $subject = $this->translator->trans('notification.comment_created');
+
         $body = $this->translator->trans('notification.comment_created.description', [
             'title' => $post->getTitle(),
             'link' => $linkToPost,

--- a/src/EventSubscriber/RedirectToPreferredLocaleSubscriber.php
+++ b/src/EventSubscriber/RedirectToPreferredLocaleSubscriber.php
@@ -37,9 +37,10 @@ final class RedirectToPreferredLocaleSubscriber implements EventSubscriberInterf
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
         string $locales,
-        string $defaultLocale = null
+        ?string $defaultLocale = null
     ) {
         $this->locales = explode('|', trim($locales));
+
         if (empty($this->locales)) {
             throw new \UnexpectedValueException('The list of supported locales must not be empty.');
         }
@@ -75,6 +76,7 @@ final class RedirectToPreferredLocaleSubscriber implements EventSubscriberInterf
         // Ignore requests from referrers with the same HTTP host in order to prevent
         // changing language for users who possibly already selected it for this application.
         $referrer = $request->headers->get('referer');
+
         if (null !== $referrer && u($referrer)->ignoreCase()->startsWith($request->getSchemeAndHttpHost())) {
             return;
         }

--- a/src/Form/DataTransformer/TagArrayToStringTransformer.php
+++ b/src/Form/DataTransformer/TagArrayToStringTransformer.php
@@ -61,7 +61,9 @@ final class TagArrayToStringTransformer implements DataTransformerInterface
         $tags = $this->tags->findBy([
             'name' => $names,
         ]);
+
         $newNames = array_diff($names, $tags);
+
         foreach ($newNames as $name) {
             $tags[] = new Tag($name);
 

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -39,7 +39,7 @@ class PostRepository extends ServiceEntityRepository
         parent::__construct($registry, Post::class);
     }
 
-    public function findLatest(int $page = 1, Tag $tag = null): Paginator
+    public function findLatest(int $page = 1, ?Tag $tag = null): Paginator
     {
         $qb = $this->createQueryBuilder('p')
             ->addSelect('a', 't')

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -64,6 +64,7 @@ final class AppExtension extends AbstractExtension
         }
 
         $this->locales = [];
+
         foreach ($this->localeCodes as $localeCode) {
             $this->locales[] = ['code' => $localeCode, 'name' => Locales::getName($localeCode, $localeCode)];
         }

--- a/src/Twig/SourceCodeExtension.php
+++ b/src/Twig/SourceCodeExtension.php
@@ -65,6 +65,7 @@ final class SourceCodeExtension extends AbstractExtension
     public function linkSourceFile(Environment $twig, string $file, int $line): string
     {
         $text = str_replace('\\', '/', $file);
+
         if (str_starts_with($text, $this->projectDir)) {
             $text = mb_substr($text, mb_strlen($this->projectDir));
         }
@@ -180,6 +181,7 @@ final class SourceCodeExtension extends AbstractExtension
         });
 
         $codeIsIndented = \count($indentedOrBlankLines) === \count($codeLines);
+
         if ($codeIsIndented) {
             $unindentedLines = array_map(static function ($lineOfCode) {
                 return u($lineOfCode)->after('    ');


### PR DESCRIPTION
Multiple-line code blocks is being separated with new line from single-line code blocks.

Also php-cs-fixer suggested fix: functions with default null arguments should accept null value.