### PR TITLE
Update doctrine.yaml

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -47,8 +47,3 @@ when@prod:
                     adapter: cache.app
                 doctrine.system_cache_pool:
                     adapter: cache.system
-
-when@dev:
-    doctrine:
-        dbal:
-            profiling_collect_backtrace: true


### PR DESCRIPTION
I removed from `doctrine.yaml` code below because since Symfony 6.4, `profiling_collect_backtrace` is here : https://github.com/symfony/demo/blob/main/config/packages/doctrine.yaml#L9

```yaml
when@dev:
    doctrine:
        dbal:
            profiling_collect_backtrace: true
```
