### PR TITLE
Make `Keep me logged in` as a translatable message

### DIFF
--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -35,7 +35,7 @@
                         <div class="form-group">
                             <label>
                                 <input type="checkbox" name="_remember_me" checked/>
-                                Keep me logged in
+                                {{ 'label.remember_me'|trans }}
                             </label>
                         </div>
                         <input type="hidden" name="_target_path" value="{{ app.request.get('redirect_to') }}"/>

--- a/translations/messages+intl-icu.ar.xlf
+++ b/translations/messages+intl-icu.ar.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>باسوورد</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>أبقني مسجلا للدخول</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>الباسوورد الحالى</target>

--- a/translations/messages+intl-icu.bg.xlf
+++ b/translations/messages+intl-icu.bg.xlf
@@ -190,6 +190,10 @@
                 <source>label.password</source>
                 <target>Парола</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Запомняне</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Роля</target>

--- a/translations/messages+intl-icu.bn.xlf
+++ b/translations/messages+intl-icu.bn.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>পাসওয়ার্ড</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>আমাকে প্রবেশকৃত অবস্থায় রাখুন</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>বর্তমান পাসওয়ার্ড</target>

--- a/translations/messages+intl-icu.bs.xlf
+++ b/translations/messages+intl-icu.bs.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>Šifra</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Ne odjavljuj me</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Trenutna šifra</target>

--- a/translations/messages+intl-icu.ca.xlf
+++ b/translations/messages+intl-icu.ca.xlf
@@ -149,6 +149,10 @@
                 <source>label.password</source>
                 <target>Contrasenya</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Mantén-me connectat</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Rol</target>

--- a/translations/messages+intl-icu.cs.xlf
+++ b/translations/messages+intl-icu.cs.xlf
@@ -133,6 +133,10 @@
                 <source>label.password</source>
                 <target>Heslo</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Přihlásit trvale</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Role</target>

--- a/translations/messages+intl-icu.de.xlf
+++ b/translations/messages+intl-icu.de.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>Passwort</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Angemeldet bleiben</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Aktuelles Passwort</target>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>Password</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Keep me logged in</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Current password</target>

--- a/translations/messages+intl-icu.es.xlf
+++ b/translations/messages+intl-icu.es.xlf
@@ -190,6 +190,10 @@
                 <source>label.password</source>
                 <target>Contraseña</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Mantener mi sesión iniciada</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Rol</target>

--- a/translations/messages+intl-icu.eu.xlf
+++ b/translations/messages+intl-icu.eu.xlf
@@ -188,6 +188,10 @@
                 <source>label.password</source>
                 <target>Pasahitza</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Manten nazazu barruan</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Rola</target>

--- a/translations/messages+intl-icu.fr.xlf
+++ b/translations/messages+intl-icu.fr.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>Mot de passe</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Garder ma session active</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Mot de passe actuel</target>

--- a/translations/messages+intl-icu.hr.xlf
+++ b/translations/messages+intl-icu.hr.xlf
@@ -187,6 +187,10 @@
                 <source>label.password</source>
                 <target>Lozinka</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Zapamti me</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Uloga</target>

--- a/translations/messages+intl-icu.id.xlf
+++ b/translations/messages+intl-icu.id.xlf
@@ -133,6 +133,10 @@
                 <source>label.password</source>
                 <target>Kata Sandi</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Biarkan saya tetap masuk log</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Peranan</target>

--- a/translations/messages+intl-icu.it.xlf
+++ b/translations/messages+intl-icu.it.xlf
@@ -194,6 +194,10 @@
                 <source>label.password</source>
                 <target>Password</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Mantienimi collegato</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Ruolo</target>

--- a/translations/messages+intl-icu.ja.xlf
+++ b/translations/messages+intl-icu.ja.xlf
@@ -133,6 +133,10 @@
                 <source>label.password</source>
                 <target>パスワード</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>ログイン状態を保持</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>ロール</target>

--- a/translations/messages+intl-icu.lt.xlf
+++ b/translations/messages+intl-icu.lt.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>Slaptažodis</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Prijungti automatiškai</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Dabartinis slaptažodis</target>

--- a/translations/messages+intl-icu.ne.xlf
+++ b/translations/messages+intl-icu.ne.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>पासवर्ड</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>मलाई प्रवेश गराइ राख्नुहोस्</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>वर्तमान पासवर्ड</target>

--- a/translations/messages+intl-icu.nl.xlf
+++ b/translations/messages+intl-icu.nl.xlf
@@ -194,6 +194,10 @@
                 <source>label.password</source>
                 <target>Wachtwoord</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Aangemeld blijven</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Rol</target>

--- a/translations/messages+intl-icu.pl.xlf
+++ b/translations/messages+intl-icu.pl.xlf
@@ -153,6 +153,10 @@
                 <source>label.password</source>
                 <target>Hasło</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Nie wylogowuj mnie</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Rola</target>

--- a/translations/messages+intl-icu.pt_BR.xlf
+++ b/translations/messages+intl-icu.pt_BR.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>Senha</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Manter-me autenticado</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Senha atual</target>

--- a/translations/messages+intl-icu.ro.xlf
+++ b/translations/messages+intl-icu.ro.xlf
@@ -153,6 +153,10 @@
                 <source>label.password</source>
                 <target>Parolă</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Păstrează-mă autentificat</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Rol</target>

--- a/translations/messages+intl-icu.ru.xlf
+++ b/translations/messages+intl-icu.ru.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>Пароль</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Оставаться в системе</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Текущий пароль</target>

--- a/translations/messages+intl-icu.sk.xlf
+++ b/translations/messages+intl-icu.sk.xlf
@@ -214,6 +214,10 @@
                 <source>label.password</source>
                 <target>Heslo</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Zapamätať si moje prihlásenie</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Aktuálne heslo</target>

--- a/translations/messages+intl-icu.sl.xlf
+++ b/translations/messages+intl-icu.sl.xlf
@@ -194,6 +194,10 @@
                 <source>label.password</source>
                 <target>Geslo</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Zapomni si me</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Vloga</target>

--- a/translations/messages+intl-icu.sq.xlf
+++ b/translations/messages+intl-icu.sq.xlf
@@ -228,6 +228,10 @@
                 <source>label.password</source>
                 <target>Fjalëkalimi</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Mbamë të futur në llogari</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Fjalëkalimi i tanishëm</target>

--- a/translations/messages+intl-icu.sr_Cyrl.xlf
+++ b/translations/messages+intl-icu.sr_Cyrl.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>Лозинка</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Не одјављуј ме</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Тренутна лозинка</target>

--- a/translations/messages+intl-icu.sr_Latn.xlf
+++ b/translations/messages+intl-icu.sr_Latn.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>Lozinka</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Ne odjavljuj me</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Trenutna lozinka</target>

--- a/translations/messages+intl-icu.tr.xlf
+++ b/translations/messages+intl-icu.tr.xlf
@@ -194,6 +194,10 @@
                 <source>label.password</source>
                 <target>Şifre</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Oturumumu açık tut</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>Rol</target>

--- a/translations/messages+intl-icu.uk.xlf
+++ b/translations/messages+intl-icu.uk.xlf
@@ -218,6 +218,10 @@
                 <source>label.password</source>
                 <target>Пароль</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>Запам'ятати мене</target>
+            </trans-unit>
             <trans-unit id="label.current_password">
                 <source>label.current_password</source>
                 <target>Поточний пароль</target>

--- a/translations/messages+intl-icu.zh_CN.xlf
+++ b/translations/messages+intl-icu.zh_CN.xlf
@@ -223,6 +223,10 @@
                 <source>label.password</source>
                 <target>密码</target>
             </trans-unit>
+            <trans-unit id="label.remember_me">
+                <source>label.remember_me</source>
+                <target>记住我的登录状态</target>
+            </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
                 <target>角色</target>


### PR DESCRIPTION
I used [Wikipedia's login page for all messages](https://es.wikipedia.org/w/index.php?title=Especial:Entrar&uselang=es). 

Some notes: 

- Wikipedia only has `pt` and this app has `pt_BR`. Generally Wikipedia's login labels are different from the demo, but I cannot really tell the cultural difference of `Keep me logged in`
- I could not find a way to trigger Wikipedia's `sr` for latin script, it always defaulted to cyrilic. I used Google's translate API to get the latin version. (It looks ok, but slavic languages are not my _forte_). 
- The demo app renders the Japanese text correctly in browser, but over GH it is just a square (test: ロ). 