### PR TITLE
Refactor how we define the available locales

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -6,6 +6,10 @@ framework:
     http_method_override: false
     handle_all_throwables: true
 
+    # this defines the codes of the locales (languages) available in the application
+    # https://symfony.com/doc/current/reference/configuration/framework.html#enabled-locales
+    enabled_locales: ['ar', 'bg', 'bn', 'bs', 'ca', 'cs', 'de', 'en', 'es', 'eu', 'fr', 'hr', 'id', 'it', 'ja', 'lt', 'ne', 'nl', 'pl', 'pt_BR', 'ro', 'ru', 'sl', 'sq', 'sr_Cyrl', 'sr_Latn', 'tr', 'uk', 'vi', 'zh_CN']
+
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     session:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -65,7 +65,7 @@ security:
     access_control:
         # this is a catch-all for the admin area
         # additional security lives in the controllers
-        - { path: '^/(%app_locales%)/admin', roles: ROLE_ADMIN }
+        - { path: '^/{_locale}/admin', roles: ROLE_ADMIN }
 
     # The ROLE_ADMIN role inherits from the ROLE_USER role
     role_hierarchy:

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -5,8 +5,6 @@
 homepage:
     path: /{_locale}
     controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController::templateAction
-    requirements:
-        _locale: '%app_locales%'
     defaults:
         template: default/homepage.html.twig
         _locale: '%locale%'
@@ -17,7 +15,5 @@ controllers:
         namespace: App\Controller
     type: attribute
     prefix: /{_locale}
-    requirements:
-        _locale: '%app_locales%'
     defaults:
         _locale: '%locale%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,8 +5,6 @@
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
     locale: 'en'
-    # This parameter defines the codes of the locales (languages) enabled in the application
-    app_locales: ar|en|fr|de|es|cs|nl|ru|uk|ro|pt_BR|pl|it|ja|id|ca|sl|sq|hr|zh_CN|bg|tr|lt|bs|sr_Cyrl|sr_Latn|eu|ne|bn|vi
     app.notifications.email_sender: anonymous@example.com
 
 services:
@@ -18,7 +16,7 @@ services:
             # this allows to define the scalar arguments once and apply them to any services
             # defined/created in this file; if some argument is used rarely, instead of defining
             # it here you can use the #[Autowire] attribute to inject it manually in the service constructor
-            string $locales: '%app_locales%'
+            array $enabledLocales: '%kernel.enabled_locales%'
             string $defaultLocale: '%locale%'
 
     # makes classes in src/ available to be used as services

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -25,22 +25,16 @@ use Twig\TwigFunction;
 final class AppExtension extends AbstractExtension
 {
     /**
-     * @var string[]
-     */
-    private readonly array $localeCodes;
-
-    /**
      * @var list<array{code: string, name: string}>|null
      */
     private ?array $locales = null;
 
     // The $locales argument is injected thanks to the service container.
     // See https://symfony.com/doc/current/service_container.html#binding-arguments-by-name-or-type
-    public function __construct(string $locales)
-    {
-        $localeCodes = explode('|', $locales);
-        sort($localeCodes);
-        $this->localeCodes = $localeCodes;
+    public function __construct(
+        /** @var string[] */
+        private array $enabledLocales,
+    ) {
     }
 
     public function getFunctions(): array
@@ -65,7 +59,7 @@ final class AppExtension extends AbstractExtension
 
         $this->locales = [];
 
-        foreach ($this->localeCodes as $localeCode) {
+        foreach ($this->enabledLocales as $localeCode) {
             $this->locales[] = ['code' => $localeCode, 'name' => Locales::getName($localeCode, $localeCode)];
         }
 


### PR DESCRIPTION
I never liked the `app_locales` parameter: https://github.com/symfony/demo/blob/main/config/services.yaml#L9

But we need it for the route locale requirements.

I was digging into how to improve this ... and realized that if we use the standard [enabled_locales](https://symfony.com/doc/current/reference/configuration/framework.html#enabled-locales) config option from Symfony, the `{_locale}` parameter included in the URLs is automatically restricted to those values.

So, we can simplify code by moving to `enabled_locales` without losing any functionality.