### PR TITLE
Fix small comment hiccup

### DIFF
--- a/src/EventSubscriber/RedirectToPreferredLocaleSubscriber.php
+++ b/src/EventSubscriber/RedirectToPreferredLocaleSubscriber.php
@@ -46,7 +46,7 @@ final class RedirectToPreferredLocaleSubscriber implements EventSubscriberInterf
 
         // Add the default locale at the first position of the array,
         // because Symfony\HttpFoundation\Request::getPreferredLanguage
-        // returns the first element when no an appropriate language is found
+        // returns the first element when no appropriate language is found
         array_unshift($this->enabledLocales, $this->defaultLocale);
         $this->enabledLocales = array_unique($this->enabledLocales);
     }


### PR DESCRIPTION
Hello, I opened this tiny PR because I noticed this little error in a comment.

Despite the size, I think it's a rather confusing error, because not knowing how locales work myself, I am not sure whether it was `an` or `no` that I should remove to fix the comment. 

Hopefully I got it right 🙏🏽 