### PR TITLE
Generate APP_SECRET in .env.local when missing

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev
-APP_SECRET=2ca64f8d83b9e89f5f19d672841d6bb8
+APP_SECRET=%generate(secret)%
 #TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 #TRUSTED_HOSTS='^(localhost|example\.com)$'
 ###< symfony/framework-bundle ###

--- a/.env.setup.php
+++ b/.env.setup.php
@@ -1,0 +1,16 @@
+<?php
+
+$env = file_get_contents('.env');
+
+if (!preg_match('{^APP_SECRET=("?)%generate\(secret\)%\1([\r\n]++)}m', $env, $m)) {
+    return;
+}
+
+$eol = $m[2];
+$local = is_file('.env.local') ? file_get_contents('.env.local') : '';
+
+if (preg_match('{^APP_SECRET=}m', $local)) {
+    return;
+}
+
+file_put_contents('.env.local', 'APP_SECRET="'.bin2hex(random_bytes(16)).'"'.$eol.$local);

--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
     },
     "scripts": {
         "auto-scripts": {
+            ".env.setup.php": "php-script",
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd",
             "importmap:install": "symfony-cmd",


### PR DESCRIPTION
The demo app needs an APP_SECRET because it uses ESI, fragments and remember-me, which all need a secret.

Instead of hardcoding a secret in `.env`, I propose here to generate one in `.env.local` on `composer i/u` when it's missing.

Inspired by the discussion on https://github.com/symfony/demo/pull/1529#issuecomment-2383545961