### PR TITLE
Add attribute `xmlns` to icons

### DIFF
--- a/config/packages/ux_icons.yaml
+++ b/config/packages/ux_icons.yaml
@@ -3,6 +3,7 @@ ux_icons:
         width: 1.2em
         height: 1.2em
         style: 'position: relative; top: -2px;'
+        xmlns: 'http://www.w3.org/2000/svg'
 
     aliases:
         'tabler:save-changes': 'tabler:device-floppy'


### PR DESCRIPTION
I allow myself to add the `xmlns="http://www.w3.org/2000/svg"` attribute.

What do you think?