### PR TITLE
Add an empty .env.dev file

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,1 @@
+# Define your env variables for the development environment here

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,4 @@
-# define your env variables for the test env here
+# Define your env variables for the test environment here
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999


### PR DESCRIPTION
For the flex recipe that generates the APP_SECRET to work the `.env.dev` file needs to exist.

Fixes #1536
