### PR TITLE
Move the twbs/bootstrap dependency from require-dev to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "symfony/validator": "^7",
         "symfony/yaml": "^7",
         "symfonycasts/sass-bundle": "^0.7",
+        "twbs/bootstrap": "^5",
         "twig/extra-bundle": "^3.3",
         "twig/intl-extra": "^3.3",
         "twig/markdown-extra": "^3.3"
@@ -64,8 +65,7 @@
         "symfony/maker-bundle": "^1.36",
         "symfony/phpunit-bridge": "^7",
         "symfony/stopwatch": "^7",
-        "symfony/web-profiler-bundle": "^7",
-        "twbs/bootstrap": "^5"
+        "symfony/web-profiler-bundle": "^7"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
I don't know if the demo is intended to work in production mode. However since the assets are no longer bundled, but generated during `composer install` with `sass:build` i think it makes sense to ensure that bootstrap is always available by moving it to the required dependencies.

Fixes #1509