### PR TITLE
Add a background color to the jumbotron on the homepage

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -414,6 +414,7 @@ body#homepage .page-header a.language-selector-dropdown-button .current-language
   margin-inline: 5px 10px;
 }
 body#homepage .jumbotron {
+  background: var(--secondary-color);
   display: flex;
   flex-direction: column;
   height: 100%;


### PR DESCRIPTION
Bootstrap dropped the jumbotron component 

https://getbootstrap.com/docs/5.3/migration/#jumbotron