### PR TITLE
Use `app.` prefix for `parameters`

### DIFF
--- a/config/packages/translation.yaml
+++ b/config/packages/translation.yaml
@@ -1,12 +1,12 @@
 # See https://symfony.com/doc/current/translation.html
 framework:
-    default_locale: '%locale%'
+    default_locale: '%app.locale%'
     translator:
         # Translations are defined using the ICU Message Format
         # See https://symfony.com/doc/current/translation/message_format.html
         default_path: '%kernel.project_dir%/translations'
         fallbacks:
-            - '%locale%'
+            - '%app.locale%'
         providers:
 #            crowdin:
 #                dsn: '%env(CROWDIN_DSN)%'

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -7,7 +7,7 @@ homepage:
     controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController::templateAction
     defaults:
         template: default/homepage.html.twig
-        _locale: '%locale%'
+        _locale: '%app.locale%'
 
 controllers:
     resource:
@@ -16,4 +16,4 @@ controllers:
     type: attribute
     prefix: /{_locale}
     defaults:
-        _locale: '%locale%'
+        _locale: '%app.locale%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,7 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
-    locale: 'en'
+    app.locale: 'en'
     app.notifications.email_sender: anonymous@example.com
 
 services:
@@ -17,7 +17,7 @@ services:
             # defined/created in this file; if some argument is used rarely, instead of defining
             # it here you can use the #[Autowire] attribute to inject it manually in the service constructor
             array $enabledLocales: '%kernel.enabled_locales%'
-            string $defaultLocale: '%locale%'
+            string $defaultLocale: '%app.locale%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name


### PR DESCRIPTION
I changed the `locale` setting to put the `app.` prefix in order to follow best practices.

https://symfony.com/doc/current/best_practices.html#use-short-and-prefixed-parameter-names :

> Consider using app. as the prefix of your [parameters](https://symfony.com/doc/current/configuration.html#configuration-parameters) to avoid collisions with Symfony and third-party bundles/libraries parameters. Then, use just one or two words to describe the purpose of the parameter