### PR TITLE
Remove importmap:install command from devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,11 +4,10 @@
     "ghcr.io/shyim/devcontainers-features/symfony-cli:0": {},
     "ghcr.io/shyim/devcontainers-features/php:0": {
       "version": "8.2"
-    },
+    }
   },
   "updateContentCommand": {
-    "composer install": ["composer", "install"],
-    "importmap:install": ["symfony", "console", "importmap:install"]
+    "composer install": ["composer", "install"]
   },
   "postAttachCommand": {
     "server": "symfony server:start",


### PR DESCRIPTION
If it is executed as part of the updateContentCommand step, the container creation fails.

importmap:install is executed by composer install though (part of the auto-scripts), which executes just fine in Codespaces.

Part of #1542