### PR TITLE
Set trusted proxies for running in Codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "features": {
     "ghcr.io/shyim/devcontainers-features/symfony-cli:0": {},
     "ghcr.io/shyim/devcontainers-features/php:0": {
-      "version": "8.2"
+      "version": "8.4"
     }
   },
   "updateContentCommand": {
@@ -12,5 +12,9 @@
   "postAttachCommand": {
     "server": "symfony server:start",
     "sass build": ["symfony", "console", "sass:build", "-w"]
+  },
+  "containerEnv": {
+    "SYMFONY_TRUSTED_PROXIES": "127.0.0.1",
+    "SYMFONY_TRUSTED_HEADERS": "x-forwarded-for,x-forwarded-host,x-forwarded-proto,x-forwarded-port"
   }
 }


### PR DESCRIPTION
Part of https://github.com/symfony/demo/issues/1542

GitHub Codespaces runs the application behind a proxy. In order to get correctly generated URLs, proxy headers must be allowed.

Also update to PHP 8.4