### PR TITLE
Remove the composer cache from the CI workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,17 +44,6 @@ jobs:
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
 
-            - name: "Set composer cache directory"
-              id: composer-cache
-              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            - name: "Cache composer"
-              uses: actions/cache@v4
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-                  restore-keys: ${{ runner.os }}-composer-
-
             - name: "Install dependencies"
               run: composer install --ansi --no-interaction --no-progress
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,18 +47,6 @@ jobs:
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            - name: "Set composer cache directory"
-              id: composer-cache
-              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-              shell: bash
-
-            - name: "Cache composer"
-              uses: actions/cache@v4
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-                  restore-keys: ${{ runner.os }}-composer-
-
             - name: "Install dependencies"
               run: composer install --ansi --no-interaction --no-progress
 


### PR DESCRIPTION
I think there is little benefit anymore for this repository to have a composer cache in the CI workflows. With composer v2 the dependencies are downloaded in parallel which is a lot faster than composer v1. This makes the performance gains from the cache small since it also takes time to setup and save or restore the cache.

Also the chance for a cache hit is low:
- This repository has low traffic and the cache expires after a week which reduces the chance for a cache hit. 
- Every branch / PR get it's own cache which again reduces the chance for a cache hit.

So I purpose to remove the composer cache to simplify the workflows.

Replaces: #1538 