### PR TITLE
Don't store the password in the session after logging in

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -145,23 +145,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function eraseCredentials(): void
     {
-        // if you had a plainPassword property, you'd nullify it here
-        // $this->plainPassword = null;
-    }
-
-    /**
-     * @return array{int|null, string|null, string|null}
-     */
-    public function __serialize(): array
-    {
-        return [$this->id, $this->username, $this->password];
-    }
-
-    /**
-     * @param array{int|null, string, string} $data
-     */
-    public function __unserialize(array $data): void
-    {
-        [$this->id, $this->username, $this->password] = $data;
+        $this->password = null;
     }
 }


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/59106

I'm wondering why we don't have the User object this way: aka why do we need a serialize function? And why don't we erase the password? Yes it's hashed, but removing it is still better to me.

Anything I'm missing?
@chalasr @stof maybe?