### PR TITLE
feat: MetaStorm integration

### DIFF
--- a/.meta-storm.xml
+++ b/.meta-storm.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<meta-storm xmlns="meta-storm">
+    <definitions>
+        <classMethod class="\Symfony\Bundle\FrameworkBundle\Controller\AbstractController" method="render" argument="0">
+            <files xpath="$project/templates" extension="" />
+        </classMethod>
+        <classMethod class="\Symfony\Bundle\FrameworkBundle\Controller\AbstractController" method="redirectToRoute" argument="0">
+            <collection name="routes" />
+        </classMethod>
+        <classMethod class="\Symfony\Component\Routing\Generator\UrlGeneratorInterface" method="generate" argument="0">
+            <collection name="routes" />
+        </classMethod>
+        <classMethod class="\Symfony\Component\String\UnicodeString" method="replaceMatches" argument="0">
+            <languageInjection language="RegExp" />
+        </classMethod>
+        <classMethod class="\Symfony\Component\DomCrawler\Crawler" method="filter" argument="0">
+            <languageInjection language="CSS" />
+        </classMethod>
+        <classMethod class="\Twig\Environment" method="render" argument="0">
+            <files xpath="$project/templates" extension="" />
+        </classMethod>
+        <classMethod class="\Doctrine\ORM\EntityRepository" method="resolveMagicCall" argument="0">
+            <methods xpath="$containingClass" />
+        </classMethod>
+        <classMethod class="\Symfony\Component\BrowserKit\AbstractBrowser" method="request" argument="0">
+            <collection name="http-methods" />
+        </classMethod>
+    </definitions>
+    <collections>
+        <attributeArgument name="routes" class="\Symfony\Component\Routing\Attribute\Route" argument="1" />
+        <strings name="http-methods">
+            <value>GET</value>
+            <value>POST</value>
+            <value>PUT</value>
+            <value>DELETE</value>
+            <value>PATCH</value>
+            <value>OPTIONS</value>
+        </strings>
+    </collections>
+</meta-storm>


### PR DESCRIPTION
MetaStorm integration.
Start integrating MetaStorm: 
- [xepozz/meta-storm-idea-plugin](http://github.com/xepozz/meta-storm-idea-plugin)
- [PHPStorm Marketplace](https://plugins.jetbrains.com/plugin/26121-metastorm?noRedirect=true)

Found a few more additional features that must be integrated to make Symfony more developer friendly. It's not replacement for Symfony PHPStorm Plugin, at least for now.

Let me know if you're interested in further MetaStorm integration. 
Thanks for any feedback. 

Here are a few screenshots what the `.meta-storm.xml` already made with the demo project.


<img width="1251" alt="image" src="https://github.com/user-attachments/assets/59360858-e3a1-4f54-bf00-f6c5a7fd5a90" />
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/e3a01b93-4f94-4916-a0ad-02165e206b0e" />
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/c720ff1e-61e6-483e-a5a7-0565e1f26e50" />
<img width="1394" alt="image" src="https://github.com/user-attachments/assets/e70dfc73-1e4a-4831-9af7-2a785d0f0bd1" />
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/c4313887-e545-41d3-a9bf-8b9c1159c377" />
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/341dd997-a6d9-4d7f-95f4-7689935b4c00" />
<img width="1347" alt="image" src="https://github.com/user-attachments/assets/bfe2cf87-531a-4a94-ad41-1e6a9036bcd1" />
<img width="861" alt="image" src="https://github.com/user-attachments/assets/2895d7cf-0df0-4b50-ab6e-34b73c203256" />
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/784ce54a-6b32-46c8-9a07-b5b07251c59a" />
