### PR TITLE
Generate APP_SECRET on create-project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,9 @@
             "importmap:install": "symfony-cmd",
             "sass:build": "symfony-cmd"
         },
+        "post-create-project-cmd": [
+            "@php -r \"echo 'APP_SECRET='.bin2hex(random_bytes(16)).PHP_EOL;\" > .env.local"
+        ],
         "post-install-cmd": [
             "@auto-scripts"
         ],


### PR DESCRIPTION
The current demo v2.7.0 doesn't work out-of-the-box anymore for new installs since the value for APP_SECRET was removed from `.env` (https://github.com/symfony/demo/commit/74d38a57102297168f8acde24c3beaabb43b3a89).

Running the following commands results in the error: "A non-empty secret is required."
```
symfony new --demo sfdemo
cd sfdemo
bin/console doctrine:schema:validate
```
I propose to generate APP_SECRET on `composer create-project` to improve the UX for new installs.

I opted to create a `.env.local` file because it works for both the production and the development environment.

Also `.env.local` is ignored by git by default and prevents contributors from accidentally committing a value for APP_SECRET to this repository.