### PR TITLE
Remove duplicates and leftovers from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-/public/build/fonts/glyphicons-*
-/public/build/images/glyphicons-*
-
 .php-version
 
 ###> symfony/framework-bundle ###
@@ -13,11 +10,6 @@
 /vendor/
 ###< symfony/framework-bundle ###
 
-###> symfony/phpunit-bridge ###
-.phpunit.result.cache
-/phpunit.xml
-###< symfony/phpunit-bridge ###
-
 ###> symfony/asset-mapper ###
 /public/assets/
 /assets/vendor/
@@ -28,6 +20,6 @@ phpstan.neon
 ###< phpstan/phpstan ###
 
 ###> phpunit/phpunit ###
-/phpunit.xml
 .phpunit.result.cache
+/phpunit.xml
 ###< phpunit/phpunit ###


### PR DESCRIPTION
Remove duplicates and leftovers from symfony/phpunit-bridge and previous bundled assets from the `.gitignore` file