### PR TITLE
Readd the APP_SECRET value

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,10 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev
-APP_SECRET=
+# in your own Symfony applications, you can leave this secret empty,
+# but in this example application, we need it so the application runs out of the box.
+# see https://symfony.com/blog/new-in-symfony-7-2-optional-secret
+APP_SECRET=2ca64f8d83b9e89f5f19d672841d6bb8
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###

--- a/.env
+++ b/.env
@@ -16,10 +16,7 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev
-# in your own Symfony applications, you can leave this secret empty,
-# but in this example application, we need it so the application runs out of the box.
-# see https://symfony.com/blog/new-in-symfony-7-2-optional-secret
-APP_SECRET=2ca64f8d83b9e89f5f19d672841d6bb8
+APP_SECRET=
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###

--- a/.env.local
+++ b/.env.local
@@ -1,4 +1,9 @@
-# in your own Symfony applications, you can leave this secret empty,
-# but in this demo application, we need it so the application runs out of the box.
-# see https://symfony.com/blog/new-in-symfony-7-2-optional-secret
+# In regular Symfony applications, this file should not be committed
+# to a shared repository. We're including it in this demo app because
+# we need to assign a value to a specific environment variable.
+# See: https://symfony.com/doc/current/configuration.html#overriding-environment-values-via-env-local
+
+# In your own Symfony projects, you can leave the secret empty.
+# However, in this demo app we provide one so it works out of the box.
+# See: https://symfony.com/blog/new-in-symfony-7-2-optional-secret
 APP_SECRET=2ca64f8d83b9e89f5f19d672841d6bb8

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,4 @@
+# in your own Symfony applications, you can leave this secret empty,
+# but in this demo application, we need it so the application runs out of the box.
+# see https://symfony.com/blog/new-in-symfony-7-2-optional-secret
+APP_SECRET=2ca64f8d83b9e89f5f19d672841d6bb8


### PR DESCRIPTION
Context:

* The promise of the "Symfony Demo" app since day one is that it works out of the box. You clone the repo or create an app based on it using Composer ... and it just works. You don't have to run any command, change any config or do anything at all. It just works.
* "Symfony Demo" is a very important application also outside the Symfony context. Folks working on PHP source code routinely use it to benchmark changes in PHP.

As explained in #1574, we're not fulfilling that promise right now because of the change made in #1532. So, let's fix that. The change proposed in #1574 is correct ... but it could be not enough. If you run Composer with the `--no-scripts` option, the proposed script won't run and the error will happen again.

So, in this PR I propose to go back to what worked before ... and add a message explaining that folks don't need to do that in their apps; this is just for the Symfony Demo. There are other parts of the app where we say _"we do this because this is a Demo app and bla bla, don't do this in your own app"_. So, this should be fine.