### PR TITLE
Add End to End tests on GitHub CI

### DIFF
--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -1,0 +1,119 @@
+name: End to End Tests
+
+on:
+    schedule:
+        # run daily at 2:00 AM UTC
+        - cron: '0 2 * * *'
+        # allow manual triggering for testing purposes
+        workflow_dispatch:
+
+jobs:
+    test-symfony-cli-installation:
+        name: Test Symfony CLI Installation
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.4'
+                  extensions: none, ctype, iconv, intl, mbstring, pdo_sqlite, xml
+                  coverage: none
+                  tools: symfony
+
+            - name: Create project using Symfony CLI
+              run: |
+                  symfony new --demo symfony_cli_test
+
+            - name: Test application
+              working-directory: ./symfony_cli_test
+              run: |
+                  php bin/console about
+                  php bin/console list
+                  php bin/console cache:clear --env=test
+
+    test-composer-create-project:
+        name: Test Composer Create Project
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.4'
+                  extensions: none, ctype, iconv, intl, mbstring, pdo_sqlite, xml
+                  tools: composer
+                  coverage: none
+
+            - name: Create project using Composer
+              run: |
+                  composer create-project symfony/symfony-demo composer_test
+
+            - name: Test application
+              working-directory: ./composer_test
+              run: |
+                  php bin/console about
+                  php bin/console list
+                  php bin/console cache:clear --env=test
+
+    test-git-clone-installation:
+        name: Test Git Clone Installation
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.4'
+                  extensions: none, ctype, iconv, intl, mbstring, pdo_sqlite, xml
+                  tools: composer
+                  coverage: none
+
+            - name: Clone repository and install dependencies
+              run: |
+                  git clone https://github.com/symfony/demo.git git_clone_test
+                  cd git_clone_test
+                  composer install --no-dev --optimize-autoloader
+
+            - name: Test application
+              working-directory: ./git_clone_test
+              run: |
+                  php bin/console about
+                  php bin/console list
+                  php bin/console cache:clear --env=test
+
+    notify-on-failure:
+        name: Notify on Failure
+        runs-on: ubuntu-latest
+        needs: [test-symfony-cli-installation, test-composer-create-project, test-git-clone-installation]
+        if: failure()
+        permissions:
+            issues: write
+
+        steps:
+            - name: Create Issue on Failure
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const title = `End to End Test Failed - ${new Date().toISOString().split('T')[0]}`;
+                      const body = `
+                          The daily end to end test workflow has failed. This means users may be experiencing issues installing the Symfony Demo application.
+
+                          **Failed Jobs:**
+                          - Check the workflow run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+                          **Installation Methods Tested:**
+                          - Symfony CLI installation
+                          - Composer create-project
+                          - Git clone + composer install
+
+                          Please investigate and fix the installation issues as soon as possible.
+                      `;
+
+                      github.rest.issues.create({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          title: title,
+                          body: body,
+                          labels: ['bug']
+                      });


### PR DESCRIPTION
To avoid issues in the future, I propose to add a daily test that checks that this application is installable and works using different methods: Symfony CLI, Composer and Git clone.