### PR TITLE
CI: run PHP CS Fixer on PHP 8.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,9 +21,9 @@ jobs:
               uses: actions/checkout@v4
 
             - name: PHP-CS-Fixer
-              uses: docker://oskarstark/php-cs-fixer-ga
+              uses: docker://ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.2
               with:
-                  args: --diff --dry-run
+                  args: check --diff --using-cache=no
 
     linters:
         name: Linters


### PR DESCRIPTION
By running PHP CS Fixer on the lowest supported PHP version of this project, which is currently PHP 8.2, PHP CS Fixer can also catch the use of invalid syntax that works only on newer PHP versions.

This [doc](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/support_new_PHP_version.rst) also recommends to run PHP CS Fixer on same PHP version as platform PHP version of the codebase.