### PR TITLE
[Bootstrap v5] Remove the custom form style

### DIFF
--- a/assets/styles/admin.css
+++ b/assets/styles/admin.css
@@ -1,7 +1,3 @@
-:root {
-  --blue: #007bff;
-}
-
 /* Page: 'Backend post index'
    ------------------------------------------------------------------------- */
 body#admin_post_index .item-actions {
@@ -23,12 +19,4 @@ body#admin_post_show .post-tags .label-default {
 }
 body#admin_post_show .post-tags .label-default i {
   color: #95A6A7;
-}
-
-.form-control {
-  border-width: .125rem;
-}
-.form-control:focus {
-  color: var(--blue);
-  box-shadow: none;
 }

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -321,45 +321,6 @@ footer #footer-resources svg {
   font-size: 21px;
 }
 
-/* Forms
-   ------------------------------------------------------------------------- */
-.form-control {
-  color: var(--gray-700);
-  height: 45px;
-}
-
-.form-group .form-control:focus {
-  color: var(--text-color);
-}
-
-.form-group.has-error .form-control {
-  border-color: var(--red);
-}
-
-.form-group.has-error .control-label {
-  color: var(--red);
-}
-
-.form-group.has-error .help-block {
-  background-color: var(--red);
-  color: var(--white);
-  font-size: 15px;
-  padding: 1em
-}
-
-.form-group.has-error .help-block ul,
-.form-group.has-error .help-block li {
-  margin-bottom: 0
-}
-
-.form-group.has-error .help-block li + li {
-  margin-top: 0.5em;
-}
-
-textarea {
-  max-width: 100%
-}
-
 /* Page: 'Technical Requirements Checker'
    ------------------------------------------------------------------------- */
 body#requirements_checker header h1 {


### PR DESCRIPTION
Form elements don't have a `.form-group` class anymore so most of the custom style doesn't work anymore.

Also the layout of textarea is broken by:
```css
.form-control {
  height: 45px;
}
```