### PR TITLE
Use `DatePoint` Doctrine Type

### DIFF
--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -17,6 +17,7 @@ use App\Entity\Tag;
 use App\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\String\AbstractUnicodeString;
 use Symfony\Component\String\Slugger\SluggerInterface;
@@ -85,7 +86,7 @@ final class AppFixtures extends Fixture
                 $comment = new Comment();
                 $comment->setAuthor($this->getReference('john_user', User::class));
                 $comment->setContent($this->getRandomText(random_int(255, 512)));
-                $comment->setPublishedAt(new \DateTimeImmutable('now + '.$i.'seconds'));
+                $comment->setPublishedAt(new DatePoint('now + '.$i.'seconds'));
 
                 $post->addComment($comment);
             }
@@ -128,7 +129,7 @@ final class AppFixtures extends Fixture
     }
 
     /**
-     * @return array<int, array{0: string, 1: AbstractUnicodeString, 2: string, 3: string, 4: \DateTimeImmutable, 5: User, 6: array<Tag>}>
+     * @return array<int, array{0: string, 1: AbstractUnicodeString, 2: string, 3: string, 4: DatePoint, 5: User, 6: array<Tag>}>
      *
      * @throws \Exception
      */
@@ -143,7 +144,7 @@ final class AppFixtures extends Fixture
                 $this->slugger->slug($title)->lower(),
                 $this->getRandomText(),
                 $this->getPostContent(),
-                new \DateTimeImmutable('now - '.$i.'days')->setTime(random_int(8, 17), random_int(7, 49), random_int(0, 59)),
+                new DatePoint('now - '.$i.'days')->setTime(random_int(8, 17), random_int(7, 49), random_int(0, 59)),
                 // Ensure that the first post is written by Jane Doe to simplify tests
                 $this->getReference(['jane_admin', 'tom_admin'][0 === $i ? 0 : random_int(0, 1)], User::class),
                 $this->getRandomTags(),

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -13,6 +13,7 @@ namespace App\Entity;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\Validator\Constraints as Assert;
 
 use function Symfony\Component\String\u;
@@ -43,8 +44,8 @@ class Comment
     #[Assert\Length(min: 5, max: 10000, minMessage: 'comment.too_short', maxMessage: 'comment.too_long')]
     private ?string $content = null;
 
-    #[ORM\Column]
-    private \DateTimeImmutable $publishedAt;
+    #[ORM\Column(type: 'date_point')]
+    private DatePoint $publishedAt;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(nullable: false)]
@@ -52,7 +53,7 @@ class Comment
 
     public function __construct()
     {
-        $this->publishedAt = new \DateTimeImmutable();
+        $this->publishedAt = new DatePoint();
     }
 
     #[Assert\IsTrue(message: 'comment.is_spam')]
@@ -78,12 +79,12 @@ class Comment
         $this->content = $content;
     }
 
-    public function getPublishedAt(): \DateTimeImmutable
+    public function getPublishedAt(): DatePoint
     {
         return $this->publishedAt;
     }
 
-    public function setPublishedAt(\DateTimeImmutable $publishedAt): void
+    public function setPublishedAt(DatePoint $publishedAt): void
     {
         $this->publishedAt = $publishedAt;
     }

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -17,6 +17,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -55,8 +56,8 @@ class Post
     #[Assert\Length(min: 10, minMessage: 'post.too_short_content')]
     private ?string $content = null;
 
-    #[ORM\Column]
-    private \DateTimeImmutable $publishedAt;
+    #[ORM\Column(type: 'date_point')]
+    private DatePoint $publishedAt;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(nullable: false)]
@@ -80,7 +81,7 @@ class Post
 
     public function __construct()
     {
-        $this->publishedAt = new \DateTimeImmutable();
+        $this->publishedAt = new DatePoint();
         $this->comments = new ArrayCollection();
         $this->tags = new ArrayCollection();
     }
@@ -120,12 +121,12 @@ class Post
         $this->content = $content;
     }
 
-    public function getPublishedAt(): \DateTimeImmutable
+    public function getPublishedAt(): DatePoint
     {
         return $this->publishedAt;
     }
 
-    public function setPublishedAt(\DateTimeImmutable $publishedAt): void
+    public function setPublishedAt(DatePoint $publishedAt): void
     {
         $this->publishedAt = $publishedAt;
     }

--- a/src/Form/Type/DateTimePickerType.php
+++ b/src/Form/Type/DateTimePickerType.php
@@ -30,7 +30,7 @@ final class DateTimePickerType extends AbstractType
         // @see https://symfony.com/doc/current/reference/forms/types/date.html#rendering-a-single-html5-text-box
         $resolver->setDefaults([
             'widget' => 'single_text',
-            'input' => 'datetime_immutable',
+            'input' => 'date_point',
             // If true, the browser will display the native date picker widget
             // however, this app uses a custom JavaScript widget, so it must be set to false
             'html5' => false,

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -16,6 +16,7 @@ use App\Entity\Tag;
 use App\Pagination\Paginator;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Clock\DatePoint;
 
 use function Symfony\Component\String\u;
 
@@ -48,7 +49,7 @@ class PostRepository extends ServiceEntityRepository
             ->leftJoin('p.tags', 't')
             ->where('p.publishedAt <= :now')
             ->orderBy('p.publishedAt', 'DESC')
-            ->setParameter('now', new \DateTimeImmutable())
+            ->setParameter('now', new DatePoint())
         ;
 
         if (null !== $tag) {


### PR DESCRIPTION
Symfony 7.3 introduced a `DatePoint` Doctrine Type. I took the liberty of making the necessary changes in the two entities that were using `DateTimeImmutable`.

- Blog: https://symfony.com/blog/new-in-symfony-7-3-dx-improvements-part-1#datepoint-doctrine-type
- Documentation: https://symfony.com/doc/current/components/clock.html#storing-datepoints-in-the-database