### PR TITLE
Return a 404 when filtering the blog by a non-existent tag

### DIFF
--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -17,7 +17,6 @@ use App\Entity\User;
 use App\Event\CommentCreatedEvent;
 use App\Form\CommentType;
 use App\Repository\PostRepository;
-use App\Repository\TagRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -49,22 +48,23 @@ final class BlogController extends AbstractController
     #[Route('/rss.xml', name: 'blog_rss', defaults: ['page' => '1', '_format' => 'xml'], methods: ['GET'])]
     #[Route('/page/{page}', name: 'blog_index_paginated', defaults: ['_format' => 'html'], requirements: ['page' => Requirement::POSITIVE_INT], methods: ['GET'])]
     #[Cache(smaxage: 10)]
-    public function index(Request $request, int $page, string $_format, PostRepository $posts, TagRepository $tags): Response
+    public function index(Request $request, int $page, string $_format, PostRepository $posts): Response
     {
-        $tag = null;
+        $tagName = $request->query->has('tag') ? (string) $request->query->get('tag') : null;
+        $latestPosts = $posts->findLatest($page, $tagName);
 
-        if ($request->query->has('tag')) {
-            $tag = $tags->findOneBy(['name' => $request->query->get('tag')]);
+        // Return a 404 instead of listing every post when the requested tag does not
+        // exist, which is both more helpful for users and better for SEO.
+        if (null !== $tagName && 0 === $latestPosts->getNumResults()) {
+            throw $this->createNotFoundException('No posts found for this tag.');
         }
-
-        $latestPosts = $posts->findLatest($page, $tag);
 
         // Every template name also has two extensions that specify the format and
         // engine for that template.
         // See https://symfony.com/doc/current/templates.html#template-naming
         return $this->render('blog/index.'.$_format.'.twig', [
             'paginator' => $latestPosts,
-            'tagName' => $tag?->getName(),
+            'tagName' => $tagName,
         ]);
     }
 

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -12,7 +12,6 @@
 namespace App\Repository;
 
 use App\Entity\Post;
-use App\Entity\Tag;
 use App\Pagination\Paginator;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -40,7 +39,7 @@ class PostRepository extends ServiceEntityRepository
         parent::__construct($registry, Post::class);
     }
 
-    public function findLatest(int $page = 1, ?Tag $tag = null): Paginator
+    public function findLatest(int $page = 1, ?string $tagName = null): Paginator
     {
         $qb = $this->createQueryBuilder('p')
             ->addSelect('a', 't')
@@ -51,9 +50,13 @@ class PostRepository extends ServiceEntityRepository
             ->setParameter('now', new \DateTimeImmutable())
         ;
 
-        if (null !== $tag) {
-            $qb->andWhere(':tag MEMBER OF p.tags')
-                ->setParameter('tag', $tag);
+        if (null !== $tagName) {
+            // Filter on a dedicated join instead of the 't' alias used by addSelect()
+            // so the posts are hydrated with all their tags, not only the one being
+            // filtered on.
+            $qb->innerJoin('p.tags', 'filterTag')
+                ->andWhere('filterTag.name = :tagName')
+                ->setParameter('tagName', $tagName);
         }
 
         return new Paginator($qb)->paginate($page);

--- a/tests/Controller/BlogControllerTest.php
+++ b/tests/Controller/BlogControllerTest.php
@@ -42,6 +42,22 @@ final class BlogControllerTest extends WebTestCase
         );
     }
 
+    public function testIndexFiltersByAnExistingTag(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/en/blog/', ['tag' => 'lorem']);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testIndexReturnsNotFoundForAnUnknownTag(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/en/blog/', ['tag' => 'this-tag-does-not-exist']);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
     public function testRss(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
Fixes #1454.

On the blog index, requesting a tag that does not exist (`/blog/?tag=this-tag-does-not-exist`) silently lists every latest post instead of telling the user the tag is unknown, because `findOneBy()` returns `null` and `findLatest()` then applies no tag filter.

As @GromNaN suggested on the issue, this returns a `404` when a tag is requested but not found, which is both more helpful for users and the expected behavior for SEO. Requesting an existing tag, or no tag at all, is unchanged.

Added two functional tests to `BlogControllerTest`: one for an existing tag (still `200`) and one for an unknown tag (now `404`).

Thanks @mindaugasvcs for the report and @GromNaN for the direction! 🙏
